### PR TITLE
feat: clorinde.toml adds to generated crate package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "auto_build_codegen"
-version = "0.10.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "deadpool-postgres",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "basic_async_codegen"
-version = "0.10.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "basic_async_wasm_codegen"
-version = "0.10.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "deadpool-postgres",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "basic_sync_codegen"
-version = "0.10.2"
+version = "0.1.0"
 dependencies = [
  "fallible-iterator",
  "postgres",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codegen"
-version = "0.10.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "custom_types_codegen"
-version = "0.10.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "generated"
-version = "0.10.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "deadpool-postgres",

--- a/benches/generated/Cargo.toml
+++ b/benches/generated/Cargo.toml
@@ -1,9 +1,10 @@
 # This file was generated with `clorinde`. Do not modify
 [package]
 name = "generated"
-version = "0.10.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
+
 
 [features]
 default = ["deadpool"]

--- a/crates/clorinde/src/cli.rs
+++ b/crates/clorinde/src/cli.rs
@@ -1,26 +1,28 @@
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
-
-use crate::{
-    config::Config, conn, container, error::Error, gen_live, gen_managed, CodegenSettings,
-};
+use crate::{config::Config, conn, container, error::Error, gen_live, gen_managed};
 
 /// Command line interface to interact with Clorinde SQL.
 #[derive(Parser, Debug)]
 #[clap(version)]
 struct Args {
+    #[clap(subcommand)]
+    action: Action,
+
+    /// Config file path
+    #[clap(short, long, default_value = "clorinde.toml")]
+    config: PathBuf,
+
     /// Use `podman` instead of `docker`
     #[clap(short, long)]
     podman: bool,
     /// Folder containing the queries
     #[clap(short, long, default_value = "queries/")]
-    queries_path: PathBuf,
+    queries: PathBuf,
     /// Destination folder for generated modules
     #[clap(short, long, default_value = "clorinde")]
     destination: PathBuf,
-    #[clap(subcommand)]
-    action: Action,
     /// Generate synchronous rust code
     #[clap(long)]
     sync: bool,
@@ -30,9 +32,6 @@ struct Args {
     /// Derive serde's `Serialize` trait for generated types.
     #[clap(long)]
     serialize: bool,
-    /// Config file path
-    #[clap(short, long, default_value = "clorinde.toml")]
-    config: PathBuf,
 }
 
 #[derive(Debug, Subcommand)]
@@ -54,7 +53,7 @@ enum Action {
 pub fn run() -> Result<(), Error> {
     let Args {
         podman,
-        queries_path,
+        queries,
         destination,
         action,
         sync,
@@ -63,27 +62,26 @@ pub fn run() -> Result<(), Error> {
         config,
     } = Args::parse();
 
-    let cfg = match config.is_file() {
+    let mut cfg = match config.is_file() {
         true => Config::from_file(config)?,
         false => Config::default(),
     };
 
-    let settings = CodegenSettings {
-        gen_async: r#async || !sync,
-        gen_sync: sync,
-        derive_ser: serialize,
-        config: cfg,
-    };
+    cfg.podman = podman;
+    cfg.queries = queries;
+    cfg.destination = destination;
+    cfg.sync = sync;
+    cfg.r#async = r#async;
+    cfg.serialize = serialize;
 
     match action {
         Action::Live { url } => {
             let mut client = conn::from_url(&url)?;
-            gen_live(&mut client, &queries_path, &destination, settings)?;
+            gen_live(&mut client, cfg)?;
         }
         Action::Schema { schema_files } => {
             // Run the generate command. If the command is unsuccessful, cleanup Clorinde's container
-            if let Err(e) = gen_managed(queries_path, &schema_files, destination, podman, settings)
-            {
+            if let Err(e) = gen_managed(&schema_files, cfg) {
                 container::cleanup(podman).ok();
                 return Err(e);
             }

--- a/crates/clorinde/src/cli.rs
+++ b/crates/clorinde/src/cli.rs
@@ -18,7 +18,7 @@ struct Args {
     #[clap(short, long)]
     podman: bool,
     /// Folder containing the queries
-    #[clap(short, long, default_value = "queries/")]
+    #[clap(short, long, alias = "queries_path", default_value = "queries/")]
     queries: PathBuf,
     /// Destination folder for generated modules
     #[clap(short, long, default_value = "clorinde")]
@@ -71,7 +71,7 @@ pub fn run() -> Result<(), Error> {
     cfg.queries = queries;
     cfg.destination = destination;
     cfg.sync = sync;
-    cfg.r#async = r#async;
+    cfg.r#async = r#async || !sync;
     cfg.serialize = serialize;
 
     match action {

--- a/crates/clorinde/src/codegen.rs
+++ b/crates/clorinde/src/codegen.rs
@@ -1,8 +1,8 @@
 use core::str;
 
 use crate::{
+    config::Config,
     prepare_queries::{Preparation, PreparedField},
-    CodegenSettings,
 };
 
 mod cargo;
@@ -133,21 +133,17 @@ pub fn idx_char(idx: usize) -> String {
     format!("T{idx}")
 }
 
-pub(crate) fn gen(name: &str, preparation: Preparation, settings: CodegenSettings) -> Vfs {
+pub(crate) fn gen(preparation: Preparation, config: &Config) -> Vfs {
     let mut vfs = Vfs::empty();
-    let cargo = cargo::gen_cargo_file(name, &preparation.dependency_analysis, settings.clone());
+    let cargo = cargo::gen_cargo_file(&preparation.dependency_analysis, &config);
     vfs.add("Cargo.toml", cargo);
     vfs.add(
         "src/lib.rs",
-        client::gen_lib(&preparation.dependency_analysis, &settings),
+        client::gen_lib(&preparation.dependency_analysis, &config),
     );
-    let types = gen_type_modules(&preparation.types, &settings.clone());
+    let types = gen_type_modules(&preparation.types, &config);
     vfs.add("src/types.rs", types);
-    queries::gen_queries(&mut vfs, &preparation, settings.clone());
-    client::gen_clients(
-        &mut vfs,
-        &preparation.dependency_analysis,
-        &settings.clone(),
-    );
+    queries::gen_queries(&mut vfs, &preparation, &config);
+    client::gen_clients(&mut vfs, &preparation.dependency_analysis, &config);
     vfs
 }

--- a/crates/clorinde/src/codegen/queries.rs
+++ b/crates/clorinde/src/codegen/queries.rs
@@ -4,8 +4,8 @@ use codegen_template::code;
 
 use crate::{
     codegen::ModCtx,
+    config::Config,
     prepare_queries::{Preparation, PreparedItem, PreparedModule, PreparedQuery},
-    CodegenSettings,
 };
 
 use super::{idx_char, vfs::Vfs, GenCtx, WARNING};
@@ -340,8 +340,8 @@ fn gen_query_fn<W: Write>(w: &mut W, module: &PreparedModule, query: &PreparedQu
     }
 }
 
-fn gen_query_module(module: &PreparedModule, settings: CodegenSettings) -> String {
-    let ctx = GenCtx::new(ModCtx::Queries, settings.gen_async, settings.derive_ser);
+fn gen_query_module(module: &PreparedModule, config: &Config) -> String {
+    let ctx = GenCtx::new(ModCtx::Queries, config.r#async, config.serialize);
     let mut w = String::new();
     code!(w => $WARNING);
 
@@ -356,26 +356,16 @@ fn gen_query_module(module: &PreparedModule, settings: CodegenSettings) -> Strin
     // TODO: remove all the .clone()
     let sync_specific = |w: &mut String| {
         let gen_sync = {
-            let gs = gen_specific(
-                module.clone(),
-                settings.clone(),
-                ModCtx::CLientQueries,
-                false,
-            );
+            let gs = gen_specific(module.clone(), config.clone(), ModCtx::CLientQueries, false);
             move |w: &mut String| gs(w)
         };
 
         let gen_async = {
-            let ga = gen_specific(
-                module.clone(),
-                settings.clone(),
-                ModCtx::CLientQueries,
-                true,
-            );
+            let ga = gen_specific(module.clone(), config.clone(), ModCtx::CLientQueries, true);
             move |w: &mut String| ga(w)
         };
 
-        if settings.gen_async && settings.gen_sync {
+        if config.r#async && config.sync {
             code!(w =>
                 pub mod sync {
                     $!gen_sync
@@ -384,10 +374,10 @@ fn gen_query_module(module: &PreparedModule, settings: CodegenSettings) -> Strin
                     $!gen_async
                 }
             );
-        } else if settings.gen_sync {
-            gen_specific(module.clone(), settings, ModCtx::Queries, false)(w);
+        } else if config.sync {
+            gen_specific(module.clone(), config.clone(), ModCtx::Queries, false)(w);
         } else {
-            gen_specific(module.clone(), settings, ModCtx::Queries, true)(w);
+            gen_specific(module.clone(), config.clone(), ModCtx::Queries, true)(w);
         }
     };
 
@@ -398,12 +388,12 @@ fn gen_query_module(module: &PreparedModule, settings: CodegenSettings) -> Strin
 
 fn gen_specific(
     module: PreparedModule,
-    settings: CodegenSettings,
+    config: Config,
     hierarchy: ModCtx,
     is_async: bool,
 ) -> impl Fn(&mut String) {
     move |w: &mut String| {
-        let ctx = GenCtx::new(hierarchy, is_async, settings.derive_ser);
+        let ctx = GenCtx::new(hierarchy, is_async, config.serialize);
         let import = if is_async {
             "use futures::{self, StreamExt, TryStreamExt}; use crate::client::async_::GenericClient;"
         } else {
@@ -422,9 +412,9 @@ fn gen_specific(
     }
 }
 
-pub(crate) fn gen_queries(vfs: &mut Vfs, preparation: &Preparation, settings: CodegenSettings) {
+pub(crate) fn gen_queries(vfs: &mut Vfs, preparation: &Preparation, config: &Config) {
     for module in &preparation.modules {
-        let gen = gen_query_module(module, settings.clone());
+        let gen = gen_query_module(module, config);
         vfs.add(format!("src/queries/{}.rs", module.info.name), gen);
     }
 
@@ -435,7 +425,7 @@ pub(crate) fn gen_queries(vfs: &mut Vfs, preparation: &Preparation, settings: Co
         $(pub mod $modules_name;)
     );
 
-    if settings.gen_async && settings.gen_sync {
+    if config.r#async && config.sync {
         let mut sync_content = String::new();
         let mut async_content = String::new();
 

--- a/crates/clorinde/src/codegen/types.rs
+++ b/crates/clorinde/src/codegen/types.rs
@@ -5,15 +5,15 @@ use indexmap::IndexMap;
 
 use crate::{
     codegen::{ModCtx, WARNING},
+    config::Config,
     prepare_queries::{Ident, PreparedContent, PreparedField, PreparedType},
-    CodegenSettings,
 };
 
 use super::GenCtx;
 
 pub(crate) fn gen_type_modules(
     prepared: &IndexMap<String, Vec<PreparedType>>,
-    settings: &CodegenSettings,
+    config: &Config,
 ) -> String {
     let mut w = String::new();
 
@@ -36,7 +36,7 @@ pub(crate) fn gen_type_modules(
 
     for (schema, types) in prepared {
         if schema == "public" {
-            let ctx = GenCtx::new(ModCtx::Types, settings.gen_async, settings.derive_ser);
+            let ctx = GenCtx::new(ModCtx::Types, config.r#async, config.serialize);
             {
                 let mut module_content = String::new();
                 for ty in types {
@@ -45,7 +45,7 @@ pub(crate) fn gen_type_modules(
                 w.push_str(&module_content);
             }
         } else {
-            let ctx = GenCtx::new(ModCtx::SchemaTypes, settings.gen_async, settings.derive_ser);
+            let ctx = GenCtx::new(ModCtx::SchemaTypes, config.r#async, config.serialize);
             {
                 let mut module_content = String::new();
                 for ty in types {

--- a/crates/clorinde/src/prepare_queries.rs
+++ b/crates/clorinde/src/prepare_queries.rs
@@ -7,11 +7,12 @@ use postgres_types::{Kind, Type};
 
 use crate::{
     codegen::{DependencyAnalysis, GenCtx, ModCtx},
+    config::Config,
     parser::{Module, NullableIdent, Query, Span, TypeAnnotation},
     read_queries::ModuleInfo,
     type_registrar::{ClorindeType, TypeRegistrar},
     utils::KEYWORD,
-    validation, CodegenSettings,
+    validation,
 };
 
 use self::error::Error;
@@ -239,9 +240,9 @@ impl PreparedModule {
 pub(crate) fn prepare(
     client: &mut Client,
     modules: Vec<Module>,
-    settings: CodegenSettings,
+    config: &Config,
 ) -> Result<Preparation, Error> {
-    let mut registrar = TypeRegistrar::new(settings.config);
+    let mut registrar = TypeRegistrar::new(config.clone());
     let mut prepared_types: IndexMap<String, Vec<PreparedType>> = IndexMap::new();
     let mut prepared_modules = Vec::new();
 

--- a/examples/auto_build/auto_build_codegen/Cargo.toml
+++ b/examples/auto_build/auto_build_codegen/Cargo.toml
@@ -1,9 +1,10 @@
 # This file was generated with `clorinde`. Do not modify
 [package]
 name = "auto_build_codegen"
-version = "0.10.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
+
 
 [features]
 default = ["deadpool"]

--- a/examples/auto_build/build.rs
+++ b/examples/auto_build/build.rs
@@ -1,4 +1,6 @@
-use clorinde::{CodegenSettings, Error};
+use std::{path::PathBuf, str::FromStr};
+
+use clorinde::{config::Config, Error};
 
 // This script will generate a new clorinde crate every time your schema or queries change.
 // In this example, we generate the module in our project, but
@@ -8,21 +10,16 @@ use clorinde::{CodegenSettings, Error};
 fn main() -> Result<(), Error> {
     let queries_path = "queries";
     let schema_file = "schema.sql";
-    let destination = "auto_build_codegen";
-    let settings = CodegenSettings {
-        gen_async: true,
-        gen_sync: false,
-        derive_ser: false,
-        config: Default::default(),
-    };
+
+    let mut cfg = Config::default();
+    cfg.destination = PathBuf::from_str("auto_build_codegen").unwrap();
 
     // This can be removed in your code
     let run_build = std::env::var("RUN_AUTO_BUILD");
-
     if run_build.is_ok() {
         println!("cargo:rerun-if-changed={queries_path}");
         println!("cargo:rerun-if-changed={schema_file}");
-        clorinde::gen_managed(queries_path, &[schema_file], destination, false, settings)?;
+        clorinde::gen_managed(&[schema_file], cfg)?;
     }
 
     Ok(())

--- a/examples/basic_async/basic_async_codegen/Cargo.toml
+++ b/examples/basic_async/basic_async_codegen/Cargo.toml
@@ -1,9 +1,10 @@
 # This file was generated with `clorinde`. Do not modify
 [package]
 name = "basic_async_codegen"
-version = "0.10.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
+
 
 [features]
 default = ["deadpool", "chrono"]

--- a/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
+++ b/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
@@ -1,9 +1,10 @@
 # This file was generated with `clorinde`. Do not modify
 [package]
 name = "basic_async_wasm_codegen"
-version = "0.10.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
+
 
 [features]
 default = ["deadpool"]

--- a/examples/basic_sync/basic_sync_codegen/Cargo.toml
+++ b/examples/basic_sync/basic_sync_codegen/Cargo.toml
@@ -1,9 +1,10 @@
 # This file was generated with `clorinde`. Do not modify
 [package]
 name = "basic_sync_codegen"
-version = "0.10.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
+
 
 [features]
 default = []

--- a/examples/custom_types/clorinde.toml
+++ b/examples/custom_types/clorinde.toml
@@ -1,2 +1,5 @@
+[package]
+name = "custom_types_codegen"
+
 [types.mapping]
 "pg_catalog.date" = "ctypes::date::Date"

--- a/examples/custom_types/custom_types_codegen/Cargo.toml
+++ b/examples/custom_types/custom_types_codegen/Cargo.toml
@@ -1,9 +1,10 @@
 # This file was generated with `clorinde`. Do not modify
 [package]
 name = "custom_types_codegen"
-version = "0.10.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
+
 
 [features]
 default = ["deadpool", "chrono"]

--- a/tests/codegen/codegen/Cargo.toml
+++ b/tests/codegen/codegen/Cargo.toml
@@ -1,9 +1,10 @@
 # This file was generated with `clorinde`. Do not modify
 [package]
 name = "codegen"
-version = "0.10.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
+
 
 [features]
 default = ["deadpool", "chrono"]

--- a/tests/integration/src/codegen.rs
+++ b/tests/integration/src/codegen.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::{reset_db, rustfmt_lib},
 };
 
-use clorinde::{CodegenSettings, Error};
+use clorinde::{config::Config, Error};
 use owo_colors::OwoColorize;
 use std::{env::set_current_dir, process::Command};
 use tempfile::tempdir;
@@ -35,13 +35,7 @@ pub(crate) fn run_codegen_test(
             // Otherwise, it is only checked.
             if apply {
                 // Generate
-                clorinde::gen_live(
-                    client,
-                    &test.queries_path,
-                    &test.destination,
-                    CodegenSettings::from(&test),
-                )
-                .map_err(Error::report)?;
+                clorinde::gen_live(client, Config::from(&test)).map_err(Error::report)?;
                 // Format the generated crate
                 rustfmt_lib(&test.destination);
             } else {
@@ -49,14 +43,12 @@ pub(crate) fn run_codegen_test(
                     .path()
                     .join(test.destination.file_name().unwrap_or("clorinde".as_ref()));
                 std::fs::create_dir(&tmp_path)?;
+
+                let mut cfg = Config::from(&test);
+                cfg.destination = tmp_path.clone();
+
                 // Generate
-                clorinde::gen_live(
-                    client,
-                    &test.queries_path,
-                    &tmp_path,
-                    CodegenSettings::from(&test),
-                )
-                .map_err(Error::report)?;
+                clorinde::gen_live(client, cfg).map_err(Error::report)?;
                 // Format the generated crate
                 rustfmt_lib(&tmp_path);
 

--- a/tests/integration/src/fixtures.rs
+++ b/tests/integration/src/fixtures.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use clorinde::{config::Config, CodegenSettings};
+use clorinde::config::Config;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -68,17 +68,25 @@ fn default_queries_path() -> PathBuf {
     PathBuf::from("queries/")
 }
 
-impl From<&CodegenTest> for CodegenSettings {
+impl From<&CodegenTest> for Config {
     fn from(codegen_test: &CodegenTest) -> Self {
-        Self {
-            gen_async: codegen_test.r#async || !codegen_test.sync,
-            gen_sync: codegen_test.sync,
-            derive_ser: codegen_test.derive_ser,
-            config: match codegen_test.config {
-                true => Config::from_file(Path::new("./clorinde.toml")).unwrap(),
-                false => Default::default(),
-            },
-        }
+        let mut cfg = match codegen_test.config {
+            true => Config::from_file(Path::new("./clorinde.toml")).unwrap(),
+            false => {
+                let mut cfg = Config::default();
+                cfg.package.name = codegen_test.destination.to_str().unwrap().to_string();
+                cfg
+            }
+        };
+
+        cfg.queries = codegen_test.queries_path.clone();
+        cfg.destination = codegen_test.destination.clone();
+
+        cfg.r#async = codegen_test.r#async;
+        cfg.sync = codegen_test.sync;
+        cfg.serialize = codegen_test.derive_ser;
+
+        cfg
     }
 }
 
@@ -91,13 +99,14 @@ pub(crate) struct ErrorTest {
     pub(crate) error: String,
 }
 
-impl From<&ErrorTest> for CodegenSettings {
+impl From<&ErrorTest> for Config {
     fn from(_error_test: &ErrorTest) -> Self {
-        Self {
-            derive_ser: false,
-            gen_async: false,
-            gen_sync: true,
-            config: Default::default(),
-        }
+        let mut cfg = Config::default();
+
+        cfg.r#async = false;
+        cfg.sync = true;
+        cfg.serialize = false;
+
+        cfg
     }
 }


### PR DESCRIPTION
Resolves #6.

- Allows the use of `[package]` in `clorinde.toml` to set the package field of the generated crate's `Cargo.toml`
```toml
[package]
name = "clorinde-crate"
version = "1.0.0"
license-file = "../LICENSE"
# ...
```

- `clorinde.toml` now takes all (first layer) cli arguments
```toml
destination = "/path/to/clorinde-crate"
podman = true
queries = "queries/"
```

- general refactor of code to use `Config` instead of `CodegenSettings`