### PR TITLE
Detect borrowed type based on std Rust types

### DIFF
--- a/crates/clorinde/src/type_registrar.rs
+++ b/crates/clorinde/src/type_registrar.rs
@@ -257,7 +257,11 @@ impl ClorindeType {
                 Type::JSON | Type::JSONB => {
                     format!("postgres_types::Json<&{lifetime} serde_json::value::RawValue>")
                 }
-                _ => (*rust_name).to_string(),
+                _ => match rust_name.as_str() {
+                    "String" => format!("&{lifetime} str"),
+                    "Vec<u8>" => format!("&{lifetime} [u8]"),
+                    _ => rust_name.to_string(),
+                },
             },
             ClorindeType::Array { inner, .. } => {
                 let inner = inner.brw_ty(is_inner_nullable, has_lifetime, ctx);


### PR DESCRIPTION
This is useful when mapping a custom type to a std Rust type, like so:

```toml
[types.mapping]
"public.ulid" = { rust_type = "String", is_copy = false }
```

(It's [hard](https://github.com/pksunkara/pgx_ulid/issues/27) to provide a ToSql/FromSql implementation for ulid.)

An alternative to hardcoding known std types would be to add an option
for the borrowed version of a type in "types.mapping".
