### PR TITLE
Don't force enable optional dependencies if wasm-async is enabled

### DIFF
--- a/crates/clorinde/src/codegen/cargo.rs
+++ b/crates/clorinde/src/codegen/cargo.rs
@@ -61,8 +61,8 @@ pub fn gen_cargo_file(dependency_analysis: &DependencyAnalysis, config: &Config)
 
         let mut wasm_features = vec!["\"tokio-postgres/js\""];
         if dependency_analysis.has_dependency() && dependency_analysis.chrono {
-            wasm_features.push("\"chrono/wasmbind\"");
-            wasm_features.push("\"time/wasm-bindgen\"");
+            wasm_features.push("\"chrono?/wasmbind\"");
+            wasm_features.push("\"time?/wasm-bindgen\"");
         }
 
         let default_features = default_features.join(", ");
@@ -79,7 +79,7 @@ pub fn gen_cargo_file(dependency_analysis: &DependencyAnalysis, config: &Config)
     } else {
         let mut wasm_features = vec![];
         if dependency_analysis.has_dependency() && dependency_analysis.chrono {
-            wasm_features.push("\"chrono/wasmbind\"");
+            wasm_features.push("\"chrono?/wasmbind\"");
         }
 
         let wasm_features = wasm_features.join(", ");

--- a/examples/basic_async/basic_async_codegen/Cargo.toml
+++ b/examples/basic_async/basic_async_codegen/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [features]
 default = ["deadpool", "chrono"]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js", "chrono/wasmbind", "time/wasm-bindgen"]
+wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]
 
 chrono = ["dep:chrono"]
 time = ["dep:time"]

--- a/examples/custom_types/custom_types_codegen/Cargo.toml
+++ b/examples/custom_types/custom_types_codegen/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [features]
 default = ["deadpool", "chrono"]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js", "chrono/wasmbind", "time/wasm-bindgen"]
+wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]
 
 chrono = ["dep:chrono"]
 time = ["dep:time"]

--- a/tests/codegen/codegen/Cargo.toml
+++ b/tests/codegen/codegen/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [features]
 default = ["deadpool", "chrono"]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js", "chrono/wasmbind", "time/wasm-bindgen"]
+wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]
 
 chrono = ["dep:chrono"]
 time = ["dep:time"]


### PR DESCRIPTION
Having

```
wasm-async = ["tokio-postgres/js", "chrono/wasmbind", "time/wasm-bindgen"]
```

Would enable both `chrono` and `time`, which would result in definition
conflicts.

This PR uses `?` syntax to enable only the feature if something else
enables the optional dependency.
