### PR TITLE
feat; add static files config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+benches/generated/* linguist-generated=true
+examples/auto_build/auto_build_codegen/* linguist-generated=true
+examples/basic_async/basic_async_codegen/* linguist-generated=true
+examples/basic_async_wasm/basic_async_wasm_codegen/* linguist-generated=true
+examples/basic_sync/basic_sync_codegen/* linguist-generated=true
+examples/custom_types/custom_types_codegen/* linguist-generated=true
+tests/codegen/codegen/* linguist-generated=true

--- a/clorinde/src/config.rs
+++ b/clorinde/src/config.rs
@@ -32,6 +32,19 @@ pub struct Config {
     pub types: Types,
     #[serde(default)]
     pub package: Package,
+    #[serde(default, rename = "static")]
+    pub static_files: Vec<StaticFile>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum StaticFile {
+    Simple(String),
+    Detailed {
+        path: String,
+        #[serde(default = "default_false")]
+        hard_link: bool,
+    },
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/clorinde/src/lib.rs
+++ b/clorinde/src/lib.rs
@@ -47,7 +47,7 @@ pub fn gen_live(client: &mut Client, config: Config) -> Result<(), Error> {
     let generated = codegen::gen(prepared_modules, &config);
 
     // Write
-    generated.persist(config.destination)?;
+    generated.persist(config.destination, config.static_files)?;
 
     Ok(())
 }
@@ -74,7 +74,7 @@ pub fn gen_managed<P: AsRef<Path>>(schema_files: &[P], config: Config) -> Result
     container::cleanup(config.podman)?;
 
     // Write
-    generated.persist(config.destination)?;
+    generated.persist(config.destination, config.static_files)?;
 
     Ok(())
 }

--- a/examples/custom_types/clorinde.toml
+++ b/examples/custom_types/clorinde.toml
@@ -1,3 +1,5 @@
+static = ["kafstel.txt"]
+
 [package]
 name = "custom_types_codegen"
 

--- a/examples/custom_types/custom_types_codegen/Cargo.toml
+++ b/examples/custom_types/custom_types_codegen/Cargo.toml
@@ -24,8 +24,8 @@ postgres-protocol = "0.6.7"
 fallible-iterator = "0.2.0"
 
 ## Custom type crates
-ctypes = { path = "../ctypes" }
 postgres_range = { version = "0.11.1", features = ["with-chrono-0_4"] }
+ctypes = { path = "../ctypes" }
 
 ## Types dependencies
 # TIME, DATE, TIMESTAMP or TIMESTAMPZ

--- a/examples/custom_types/custom_types_codegen/kafstel.txt
+++ b/examples/custom_types/custom_types_codegen/kafstel.txt
@@ -1,0 +1,1 @@
+I'm going to be copied into the codegen directory!

--- a/examples/custom_types/kafstel.txt
+++ b/examples/custom_types/kafstel.txt
@@ -1,0 +1,1 @@
+I'm going to be copied into the codegen directory!


### PR DESCRIPTION
resolves #7 and #45.

- Adds a new option to `clorinde.toml`: `static` that lists files you want copied to the generated directory. Has ability to hard link files instead if they are large and you don't want them copied.
- Adds a `.gitattributes` and marks all codegen files in the repo as generated. This should make reviews easier, while keeping the ability to track diffs.