### PR TITLE
feat: add query doc strings

### DIFF
--- a/benches/generated/src/queries/bench.rs
+++ b/benches/generated/src/queries/bench.rs
@@ -356,6 +356,10 @@ pub mod sync {
             }
         }
     }
+    /// Performs a bulk insert of multiple users.
+    ///
+    /// Clorinde doesn't support multi-value inserts, so we use `unnest` to transform two arrays
+    /// (names and hair_colors) into rows of values that can be inserted together.
     pub fn insert_user() -> InsertUserStmt {
         InsertUserStmt(crate::client::sync::Stmt::new(
             "INSERT INTO users (name, hair_color) SELECT unnest($1::text[]) as name, unnest($2::text[]) as hair_color",
@@ -779,6 +783,10 @@ pub mod async_ {
             }
         }
     }
+    /// Performs a bulk insert of multiple users.
+    ///
+    /// Clorinde doesn't support multi-value inserts, so we use `unnest` to transform two arrays
+    /// (names and hair_colors) into rows of values that can be inserted together.
     pub fn insert_user() -> InsertUserStmt {
         InsertUserStmt(crate::client::async_::Stmt::new(
             "INSERT INTO users (name, hair_color) SELECT unnest($1::text[]) as name, unnest($2::text[]) as hair_color",

--- a/benches/queries/bench.sql
+++ b/benches/queries/bench.sql
@@ -6,6 +6,10 @@
 SELECT * FROM users;
 
 --! insert_user
+--- Performs a bulk insert of multiple users.
+---
+--- Clorinde doesn't support multi-value inserts, so we use `unnest` to transform two arrays
+--- (names and hair_colors) into rows of values that can be inserted together.
 INSERT INTO users (name, hair_color)
 SELECT unnest(:names::text[]) as name,
        unnest(:hair_colors::text[]) as hair_color;

--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -240,6 +240,7 @@ fn gen_query_fn(
     let PreparedQuery {
         ident,
         row,
+        comments,
         sql,
         param,
     } = query;
@@ -397,7 +398,13 @@ fn gen_query_fn(
         .collect::<Vec<&str>>()
         .join(" ");
 
+    let doc_comments = comments.iter().map(|comment| {
+        let comment_with_space = format!(" {}", comment);
+        quote! { #[doc = #comment_with_space] }
+    });
+
     let struct_tokens = quote! {
+        #(#doc_comments)*
         pub fn #name() -> #stmt_ident {
             #stmt_ident(#client::Stmt::new(#sql))
         }

--- a/clorinde/src/parser.rs
+++ b/clorinde/src/parser.rs
@@ -214,14 +214,14 @@ impl Query {
                 // Dollar quotes ($$ or $tag$)
                 '$' => {
                     let mut content = String::from("$");
-                    while let Some(x) = chars.next() {
+                    for x in chars.by_ref() {
                         content.push(x);
                         if x == '$' {
                             break;
                         }
                     }
                     let tag = content.clone();
-                    while let Some(x) = chars.next() {
+                    for x in chars.by_ref() {
                         content.push(x);
                         if content.ends_with(&tag) {
                             break;
@@ -446,6 +446,7 @@ impl QueryDataStruct {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 enum Statement {
     Type(TypeAnnotation),

--- a/clorinde/src/parser.rs
+++ b/clorinde/src/parser.rs
@@ -7,7 +7,7 @@ use miette::SourceSpan;
 
 use crate::read_queries::ModuleInfo;
 
-/// Th    if is data structure holds a value and the context in which it was parsed.
+/// This data structure holds a value and the context in which it was parsed.
 /// This context is used for error reporting.
 #[derive(Debug, Clone)]
 pub struct Span<T> {
@@ -149,6 +149,7 @@ impl TypeAnnotation {
 pub(crate) struct Query {
     pub(crate) name: Span<String>,
     pub(crate) param: QueryDataStruct,
+    pub(crate) comments: Vec<String>,
     pub(crate) row: QueryDataStruct,
     pub(crate) sql_span: SourceSpan,
     pub(crate) sql_str: String,
@@ -201,6 +202,72 @@ impl Query {
             .ignored()
     }
 
+    /// Removes regular SQL comments (starting with '--') while making sure to preserve:
+    /// - String literals (both 'single' and "double" quoted)
+    /// - Dollar-quoted strings ($$text$$ or $tag$text$tag$)
+    fn clean_sql_comments(sql: &str) -> String {
+        let mut result = String::new();
+        let mut chars = sql.chars().peekable();
+
+        while let Some(c) = chars.next() {
+            match c {
+                // Dollar quotes ($$ or $tag$)
+                '$' => {
+                    let mut content = String::from("$");
+                    while let Some(x) = chars.next() {
+                        content.push(x);
+                        if x == '$' {
+                            break;
+                        }
+                    }
+                    let tag = content.clone();
+                    while let Some(x) = chars.next() {
+                        content.push(x);
+                        if content.ends_with(&tag) {
+                            break;
+                        }
+                    }
+                    result.push_str(&content);
+                }
+                // String literals
+                '\'' | '"' => {
+                    let quote = c;
+                    let mut content = String::from(quote);
+                    while let Some(x) = chars.next() {
+                        content.push(x);
+                        if x == '\\' {
+                            if let Some(escaped) = chars.next() {
+                                content.push(escaped);
+                            }
+                        } else if x == quote {
+                            break;
+                        }
+                    }
+                    result.push_str(&content);
+                }
+                // Comments
+                '-' if chars.peek() == Some(&'-') => {
+                    chars.next(); // consume second dash
+                    if matches!(chars.peek(), Some(&':') | Some(&'!')) {
+                        result.push_str("--");
+                        if let Some(x) = chars.next() {
+                            result.push(x);
+                        }
+                    } else {
+                        while let Some(&x) = chars.peek() {
+                            if x == '\n' {
+                                break;
+                            }
+                            chars.next();
+                        }
+                    }
+                }
+                _ => result.push(c),
+            }
+        }
+        result
+    }
+
     /// Parse all bind from an SQL query
     fn parse_bind() -> impl Parser<char, Vec<Span<String>>, Error = Simple<char>> {
         just(':')
@@ -213,11 +280,22 @@ impl Query {
     /// Parse sql query, normalizing named parameters
     fn parse_sql_query()
     -> impl Parser<char, (String, SourceSpan, Vec<Span<String>>), Error = Simple<char>> {
+        // TODO(bug): Using none_of(";") breaks on the first semicolon it encounters, even if that semicolon is inside:
+        // - String literals: 'text with ; in it'
+        // - Dollar-quoted strings: $$text with ; in it$$
+        // - Comments: -- comment with ; in it
+        // We need proper SQL token awareness to know if a semicolon is part of these constructs or if it's the actual query terminator.
         none_of(";")
             .repeated()
             .then_ignore(just(';'))
             .collect::<String>()
             .map_with_span(|mut sql_str, span: Range<usize>| {
+                sql_str = Self::clean_sql_comments(&sql_str)
+                    .lines()
+                    .filter(|line| !line.trim().is_empty())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
                 let bind_params: Vec<_> = Self::parse_bind().parse(sql_str.clone()).unwrap();
                 // Remove duplicate
                 let dedup_params: Vec<_> = bind_params
@@ -238,6 +316,18 @@ impl Query {
 
                 (sql_str, span.into(), dedup_params)
             })
+    }
+
+    fn parse_comments() -> impl Parser<char, Vec<String>, Error = Simple<char>> {
+        just("---")
+            .ignore_then(
+                none_of('\n')
+                    .repeated()
+                    .collect::<String>()
+                    .map(|s| s.trim().to_string()),
+            )
+            .then_ignore(ln())
+            .repeated()
     }
 
     fn parse_query_annotation()
@@ -262,11 +352,13 @@ impl Query {
         Self::parse_query_annotation()
             .then_ignore(space())
             .then_ignore(ln())
+            .then(Self::parse_comments())
             .then(Self::parse_sql_query())
             .map(
-                |((name, param, row), (sql_str, sql_span, bind_params))| Self {
+                |(((name, param, row), comments), (sql_str, sql_span, bind_params))| Self {
                     name,
                     param,
+                    comments,
                     row,
                     sql_span,
                     sql_str,

--- a/clorinde/src/prepare_queries.rs
+++ b/clorinde/src/prepare_queries.rs
@@ -23,6 +23,7 @@ use self::error::Error;
 pub(crate) struct PreparedQuery {
     pub(crate) ident: Ident,
     pub(crate) param: Option<(usize, Vec<usize>)>,
+    pub(crate) comments: Vec<String>,
     pub(crate) row: Option<(usize, Vec<usize>)>,
     pub(crate) sql: String,
 }
@@ -219,6 +220,7 @@ impl PreparedModule {
     fn add_query(
         &mut self,
         name: Span<String>,
+        comments: Vec<String>,
         param_idx: Option<(usize, Vec<usize>)>,
         row_idx: Option<(usize, Vec<usize>)>,
         sql: String,
@@ -228,6 +230,7 @@ impl PreparedModule {
             PreparedQuery {
                 ident: Ident::new(name.value),
                 row: row_idx,
+                comments,
                 sql,
                 param: param_idx,
             },
@@ -374,6 +377,7 @@ fn prepare_query(
     Query {
         name,
         param,
+        comments,
         bind_params,
         row,
         sql_str,
@@ -460,7 +464,7 @@ fn prepare_query(
     } else {
         Some(module.add_param(params_name, params_fields, param.is_implicit())?)
     };
-    module.add_query(name.clone(), param_idx, row_idx, sql_str);
+    module.add_query(name.clone(), comments, param_idx, row_idx, sql_str);
 
     Ok(())
 }

--- a/tests/codegen/queries/syntax.sql
+++ b/tests/codegen/queries/syntax.sql
@@ -2,20 +2,20 @@
 --:CompactRow()
      --:          SpaceRow     ()
 --:CompactField(a?,b?,c?)
---: SpaceField      (  a?   ,  b?  ,  c?  )   
+--: SpaceField      (  a?   ,  b?  ,  c?  )
 
 --simple comment
 
 --! select_compact
 SELECT * FROM clone;
-      --!      select_spaced   
-      SELECT * FROM clone ;   
+      --!      select_spaced
+      SELECT * FROM clone ;
 
   --        spaced comment
 
 --!implicit_compact(name?,price?):(id?)
 INSERT INTO named (name, price, show) VALUES (:name, :price, false) RETURNING id;
-             --!  implicit_spaced        (     name? , price? ) :       ( id? ) 
+             --!  implicit_spaced        (     name? , price? ) :       ( id? )
 INSERT INTO named (name, price, show) VALUES (:name, :price, false) RETURNING id;
 
 -- Multi line
@@ -23,7 +23,7 @@ INSERT INTO named (name, price, show) VALUES (:name, :price, false) RETURNING id
 
 --!named_compact Params():Row()
 INSERT INTO named (name, price, show) VALUES (:name, :price, false) RETURNING id;
-      --!       named_spaced            ParamsSpace  ()     :        RowSpace  () 
+      --!       named_spaced            ParamsSpace  ()     :        RowSpace  ()
 INSERT INTO named (name, price, show) VALUES (:name, :price, false) RETURNING id;
 
 --! tricky_sql
@@ -53,3 +53,20 @@ SELECT * FROM syntax;
 -- Multi
 
 -- Comment
+
+--! select_comment
+--- Multi line
+---
+--- Doc string comment
+SELECT * FROM syntax;
+
+--! select_inline_comment
+SELECT
+    -- remove this comment:
+    '-- dont remove this' as c1,          -- and this:
+    $$-- or this$$ as c2,                 -- and this
+    E'-- escape string here' as c3,       -- this too
+    -- you guess it, this too
+    e'-- another escape string' as c4,    -- and this
+    $tag$-- dollar quoted here$tag$ as c5 -- finally this
+;

--- a/tests/codegen/src/main.rs
+++ b/tests/codegen/src/main.rs
@@ -45,8 +45,8 @@ use codegen::{
             },
         },
         syntax::{
-            TrickySql10Params,
-            sync::{tricky_sql10, r#typeof},
+            SelectInlineComment, TrickySql10Params,
+            sync::{select_inline_comment, tricky_sql10, r#typeof},
         },
     },
     types::{
@@ -76,6 +76,7 @@ pub fn main() {
     test_domain(client);
     test_trait_sql(client);
     test_keyword_escaping(client);
+    test_inline_comment(client);
 }
 
 pub fn test_params(client: &mut Client) {
@@ -617,4 +618,17 @@ pub fn test_keyword_escaping(client: &mut Client) {
     };
     tricky_sql10().params(client, &params).unwrap();
     r#typeof().bind(client).all().unwrap();
+}
+
+// Test inline comment removing
+pub fn test_inline_comment(client: &mut Client) {
+    let expected = SelectInlineComment {
+        c1: "-- dont remove this".to_string(),
+        c2: "-- or this".to_string(),
+        c3: "-- escape string here".to_string(),
+        c4: "-- another escape string".to_string(),
+        c5: "-- dollar quoted here".to_string(),
+    };
+    let actual = select_inline_comment().bind(client).one().unwrap();
+    assert_eq!(expected, actual);
 }


### PR DESCRIPTION
Wanted to learn how the parsing works, figured https://github.com/cornucopia-rs/cornucopia/issues/165 would be a good issue to tackle.

- Adds `---` comments after query declarations that get added as doc strings (`///`) to the generated Rust code.

```sql
--! insert_user
--- This performs a bulk insert using unnest
--- because VALUES isn't supported for parameterized bulk inserts
INSERT INTO users (name, hair_color)
SELECT unnest(:names::text[]) as name,
       unnest(:hair_colors::text[]) as hair_color;
```

Generates:
```rust
/// This performs a bulk insert using unnest
/// because VALUES isn't supported for parameterized bulk inserts
pub fn insert_user() -> InsertUserStmt {
    // ...
}
```

- Fixes a bug with sql comments being added to the query (and added tests). With the query now having formatting removed when codegen'd, this would cause issues.

Example:
```sql
--! select
SELECT * -- This is a comment
FROM user;
```

Would generate:

```rust
SelectStmt(crate::client::sync::Stmt::new(
    "SELECT * -- This is a comment FROM user",
))
```

Now it removes the comment:

```rust
SelectStmt(crate::client::sync::Stmt::new(
    "SELECT * FROM user",
))
```
- Re-discovered this bug: https://github.com/cornucopia-rs/cornucopia/issues/239. Found and wrote a comment on the root cause in `parse_sql_query`. I believe it will require a bit of work to fix, so I'm leaving it for later.