### PR TITLE
feat: add derive traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "bytes",
  "postgres-protocol",
  "postgres-types",
+ "serde",
  "time",
 ]
 
@@ -730,6 +731,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "postgres_range",
+ "serde",
  "time",
  "tokio-postgres",
 ]

--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -54,10 +54,15 @@ fn gen_params_struct(params: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenS
     }
 }
 
-fn gen_row_structs(row: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenStream {
+fn gen_row_structs(
+    row: &PreparedItem,
+    derive_traits: &Vec<String>,
+    ctx: &GenCtx,
+) -> proc_macro2::TokenStream {
     let PreparedItem {
         name,
         fields,
+        traits,
         is_copy,
         ..
     } = row;
@@ -83,8 +88,13 @@ fn gen_row_structs(row: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenStream
         quote!()
     };
 
+    let trait_attrs = traits
+        .iter()
+        .chain(derive_traits.iter())
+        .map(|t| syn::parse_str::<proc_macro2::TokenStream>(t).unwrap_or_else(|_| quote!()));
+
     let main_struct = quote! {
-        #[derive(#ser_attr Debug, Clone, PartialEq #copy_attr)]
+        #[derive(#ser_attr Debug, Clone, PartialEq #copy_attr #(,#trait_attrs)*)]
         pub struct #name_ident {
             #(pub #fields_name: #fields_ty,)*
         }
@@ -515,7 +525,7 @@ fn gen_query_module(module: &PreparedModule, config: &Config) -> proc_macro2::To
 
     for row in module.rows.values() {
         if row.is_named {
-            let row_tokens = gen_row_structs(row, &ctx);
+            let row_tokens = gen_row_structs(row, &config.types.derive_traits, &ctx);
             tokens.extend(quote!(#row_tokens));
         }
     }

--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -56,7 +56,7 @@ fn gen_params_struct(params: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenS
 
 fn gen_row_structs(
     row: &PreparedItem,
-    derive_traits: &Vec<String>,
+    derive_traits: &[String],
     ctx: &GenCtx,
 ) -> proc_macro2::TokenStream {
     let PreparedItem {

--- a/clorinde/src/codegen/types.rs
+++ b/clorinde/src/codegen/types.rs
@@ -35,7 +35,12 @@ pub(crate) fn gen_type_modules(
             let ctx = GenCtx::new(ModCtx::Types, config.r#async, config.serialize);
             {
                 for ty in types {
-                    tokens.extend(gen_custom_type(schema, ty, &ctx))
+                    tokens.extend(gen_custom_type(
+                        schema,
+                        ty,
+                        &config.types.derive_traits,
+                        &ctx,
+                    ))
                 }
             }
         } else {
@@ -43,7 +48,12 @@ pub(crate) fn gen_type_modules(
             {
                 let mut p_tokens = quote!();
                 for ty in types {
-                    p_tokens.extend(gen_custom_type(schema, ty, &ctx))
+                    p_tokens.extend(gen_custom_type(
+                        schema,
+                        ty,
+                        &config.types.derive_traits,
+                        &ctx,
+                    ))
                 }
                 let schema_name = format_ident!("{}", schema);
                 tokens.extend(quote! {
@@ -64,6 +74,7 @@ pub(crate) fn gen_type_modules(
 fn gen_custom_type(
     schema: &str,
     prepared: &PreparedType,
+    derive_traits: &Vec<String>,
     ctx: &GenCtx,
 ) -> proc_macro2::TokenStream {
     let PreparedType {
@@ -72,6 +83,7 @@ fn gen_custom_type(
         is_copy,
         is_params,
         name,
+        traits,
     } = prepared;
 
     let struct_name_ident = format_ident!("{}", struct_name);
@@ -86,13 +98,18 @@ fn gen_custom_type(
         quote!()
     };
 
+    let trait_attrs = traits
+        .iter()
+        .chain(derive_traits.iter())
+        .map(|t| syn::parse_str::<proc_macro2::TokenStream>(t).unwrap_or_else(|_| quote!()));
+
     match content {
         PreparedContent::Enum(variants) => {
             let variants_ident: Vec<_> =
                 variants.iter().map(|v| format_ident!("{}", v.rs)).collect();
 
             let enum_def = quote! {
-                #[derive(#ser_attr Debug, Clone, Copy, PartialEq, Eq)]
+                #[derive(#ser_attr Debug, Clone, Copy, PartialEq, Eq #(,#trait_attrs)*)]
                 #[allow(non_camel_case_types)]
                 pub enum #struct_name_ident {
                     #(#variants_ident,)*
@@ -122,7 +139,7 @@ fn gen_custom_type(
                 .collect();
 
             let struct_def = quote! {
-                #[derive(#ser_attr Debug, postgres_types::FromSql, #copy_attr Clone, PartialEq)]
+                #[derive(#ser_attr Debug, postgres_types::FromSql, #copy_attr Clone, PartialEq #(,#trait_attrs)*)]
                 #[postgres(name = #name_lit)]
                 pub struct #struct_name_ident {
                     #(

--- a/clorinde/src/codegen/types.rs
+++ b/clorinde/src/codegen/types.rs
@@ -74,7 +74,7 @@ pub(crate) fn gen_type_modules(
 fn gen_custom_type(
     schema: &str,
     prepared: &PreparedType,
-    derive_traits: &Vec<String>,
+    derive_traits: &[String],
     ctx: &GenCtx,
 ) -> proc_macro2::TokenStream {
     let PreparedType {

--- a/clorinde/src/config.rs
+++ b/clorinde/src/config.rs
@@ -9,38 +9,67 @@ use std::{
 };
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
+    // Shared with CLI
     /// Use `podman` instead of `docker`
-    #[serde(default = "default_false")]
     pub podman: bool,
     /// Directory containing the queries
-    #[serde(default = "default_queries")]
     pub queries: PathBuf,
     /// Destination folder for generated modules
-    #[serde(default = "default_destination")]
     pub destination: PathBuf,
     /// Generate synchronous rust code
-    #[serde(default = "default_false")]
     pub sync: bool,
     /// Generate asynchronous rust code
-    #[serde(default = "default_true")]
     pub r#async: bool,
     /// Derive serde's `Serialize` trait for generated types
-    #[serde(default = "default_false")]
     pub serialize: bool,
 
+    // Config file exclusive
     /// Custom type settings
-    #[serde(default)]
     pub types: Types,
     /// The `package` table of the generated `Cargo.toml`
-    #[serde(default)]
     pub package: Package,
     /// List of static files to copy into the generated directory
-    #[serde(default, rename = "static")]
+    #[serde(rename = "static")]
     pub static_files: Vec<StaticFile>,
     /// Use workspace dependencies
-    #[serde(default, rename = "use-workspace-deps")]
+    #[serde(rename = "use-workspace-deps")]
     pub use_workspace_deps: UseWorkspaceDeps,
+}
+
+impl Config {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
+        let contents = fs::read_to_string(path)?;
+        let config = toml::from_str(&contents)?;
+        Ok(config)
+    }
+
+    pub(crate) fn get_type_mapping(&self, ty: &Type) -> Option<&TypeMapping> {
+        let key = format!("{}.{}", ty.schema(), ty.name());
+        self.types.mapping.get(&key)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            podman: false,
+            queries: PathBuf::from_str("queries/").unwrap(),
+            destination: PathBuf::from_str("clorinde").unwrap(),
+            sync: false,
+            r#async: true,
+            serialize: false,
+            types: Types {
+                crate_info: HashMap::new(),
+                mapping: HashMap::new(),
+                derive_traits: vec![],
+            },
+            package: Package::default(),
+            static_files: vec![],
+            use_workspace_deps: UseWorkspaceDeps::Bool(false),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -49,7 +78,7 @@ pub enum StaticFile {
     Simple(PathBuf),
     Detailed {
         path: PathBuf,
-        #[serde(default = "default_false", rename = "hard-link")]
+        #[serde(default, rename = "hard-link")]
         hard_link: bool,
     },
 }
@@ -68,15 +97,15 @@ impl Default for UseWorkspaceDeps {
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Types {
     /// Crates to add as a dependency for custom types
-    #[serde(default, rename = "crates")]
+    #[serde(rename = "crates")]
     pub crate_info: HashMap<String, CrateDependency>,
     /// Mapping for custom types
-    #[serde(default)]
     pub mapping: HashMap<String, TypeMapping>,
     /// Derive traits added to all generated row structs
-    #[serde(default, rename = "derive-traits")]
+    #[serde(rename = "derive-traits")]
     pub derive_traits: Vec<String>,
 }
 
@@ -90,6 +119,7 @@ pub enum CrateDependency {
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct DependencyTable {
     pub version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -146,24 +176,20 @@ pub enum TypeMapping {
     Detailed {
         #[serde(rename = "rust-type")]
         rust_type: String,
-        #[serde(rename = "is-copy", default = "default_true")]
+        #[serde(default = "default_true", rename = "is-copy")]
         is_copy: bool,
-        #[serde(rename = "is-params", default = "default_true")]
+        #[serde(default = "default_true", rename = "is-params")]
         is_params: bool,
     },
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default, deny_unknown_fields)]
 pub struct Package {
-    #[serde(default = "default_name")]
     pub name: String,
-    #[serde(default = "default_version")]
     pub version: String,
-    #[serde(default = "default_edition")]
     pub edition: String,
-    #[serde(default = "default_publish")]
     pub publish: Publish,
-
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authors: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -223,40 +249,6 @@ impl Default for Publish {
     }
 }
 
-impl Config {
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
-        let contents = fs::read_to_string(path)?;
-        let config = toml::from_str(&contents)?;
-        Ok(config)
-    }
-
-    pub(crate) fn get_type_mapping(&self, ty: &Type) -> Option<&TypeMapping> {
-        let key = format!("{}.{}", ty.schema(), ty.name());
-        self.types.mapping.get(&key)
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            podman: false,
-            queries: default_queries(),
-            destination: default_destination(),
-            sync: false,
-            r#async: true,
-            serialize: false,
-            types: Types {
-                crate_info: HashMap::new(),
-                mapping: HashMap::new(),
-                derive_traits: vec![],
-            },
-            package: Package::default(),
-            static_files: vec![],
-            use_workspace_deps: UseWorkspaceDeps::Bool(false),
-        }
-    }
-}
-
 impl Package {
     pub fn to_string(&self) -> Result<String> {
         let mut output = String::from("[package]\n");
@@ -268,10 +260,10 @@ impl Package {
 impl Default for Package {
     fn default() -> Self {
         Self {
-            name: default_name(),
-            version: default_version(),
-            edition: default_edition(),
-            publish: default_publish(),
+            name: "clorinde".to_string(),
+            version: "0.1.0".to_string(),
+            edition: "2021".to_string(),
+            publish: Publish::default(),
             authors: None,
             description: None,
             documentation: None,
@@ -308,32 +300,4 @@ pub enum ConfigError {
 
 fn default_true() -> bool {
     true
-}
-
-fn default_false() -> bool {
-    false
-}
-
-fn default_queries() -> PathBuf {
-    PathBuf::from_str("queries/").unwrap()
-}
-
-fn default_destination() -> PathBuf {
-    PathBuf::from_str("clorinde").unwrap()
-}
-
-fn default_name() -> String {
-    "clorinde".to_string()
-}
-
-fn default_version() -> String {
-    "0.1.0".to_string()
-}
-
-fn default_edition() -> String {
-    "2021".to_string()
-}
-
-fn default_publish() -> Publish {
-    Publish::default()
 }

--- a/clorinde/src/config.rs
+++ b/clorinde/src/config.rs
@@ -75,6 +75,9 @@ pub struct Types {
     /// Mapping for custom types
     #[serde(default)]
     pub mapping: HashMap<String, TypeMapping>,
+    /// Derive traits added to all generated row structs
+    #[serde(default, rename = "derive-traits")]
+    pub derive_traits: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -245,6 +248,7 @@ impl Default for Config {
             types: Types {
                 crate_info: HashMap::new(),
                 mapping: HashMap::new(),
+                derive_traits: vec![],
             },
             package: Package::default(),
             static_files: vec![],

--- a/clorinde/src/parser.rs
+++ b/clorinde/src/parser.rs
@@ -132,16 +132,33 @@ fn parse_nullable_ident() -> impl Parser<char, Vec<NullableIdent>, Error = Simpl
 pub struct TypeAnnotation {
     pub name: Span<String>,
     pub fields: Vec<NullableIdent>,
+    pub traits: Vec<String>,
 }
 
 impl TypeAnnotation {
     fn parser() -> impl Parser<char, Self, Error = Simple<char>> {
+        let trait_parser = ident()
+            .map(|s: Span<String>| s.value)
+            .separated_by(just(',').padded())
+            .or(empty().map(|_| Vec::new()));
+
         just("--:")
             .ignore_then(space())
             .ignore_then(ident())
             .then_ignore(space())
             .then(parse_nullable_ident())
-            .map(|(name, fields)| Self { name, fields })
+            .then_ignore(space())
+            .then(
+                just(':')
+                    .ignore_then(space())
+                    .ignore_then(trait_parser)
+                    .or_not(),
+            )
+            .map(|((name, fields), traits)| Self {
+                name,
+                fields,
+                traits: traits.unwrap_or_default(),
+            })
     }
 }
 
@@ -379,23 +396,22 @@ impl QueryDataStruct {
         registered_structs: &'a [TypeAnnotation],
         query_name: &Span<String>,
         name_suffix: Option<&str>,
-    ) -> (&'a [NullableIdent], Span<String>) {
+    ) -> (&'a [NullableIdent], Vec<String>, Span<String>) {
         if let Some(named) = &self.name {
+            let registered = registered_structs.iter().find(|it| it.name == *named);
+
             (
                 self.idents.as_ref().map_or_else(
-                    || {
-                        registered_structs
-                            .iter()
-                            .find_map(|it| (it.name == *named).then_some(it.fields.as_slice()))
-                            .unwrap_or(&[])
-                    },
+                    || registered.map(|it| it.fields.as_slice()).unwrap_or(&[]),
                     Vec::as_slice,
                 ),
+                registered.map(|it| it.traits.clone()).unwrap_or_default(),
                 named.clone(),
             )
         } else {
             (
                 self.idents.as_ref().map_or(&[], Vec::as_slice),
+                vec![],
                 query_name.map(|x| {
                     format!(
                         "{}{}",

--- a/clorinde/src/prepare_queries.rs
+++ b/clorinde/src/prepare_queries.rs
@@ -99,19 +99,26 @@ impl PreparedField {
 pub(crate) struct PreparedItem {
     pub(crate) name: Span<String>,
     pub(crate) fields: Vec<PreparedField>,
+    pub(crate) traits: Vec<String>,
     pub(crate) is_copy: bool,
     pub(crate) is_named: bool,
     pub(crate) is_ref: bool,
 }
 
 impl PreparedItem {
-    pub fn new(name: Span<String>, fields: Vec<PreparedField>, is_implicit: bool) -> Self {
+    pub fn new(
+        name: Span<String>,
+        fields: Vec<PreparedField>,
+        traits: Vec<String>,
+        is_implicit: bool,
+    ) -> Self {
         Self {
             name,
             is_copy: fields.iter().all(|f| f.ty.is_copy()),
             is_ref: fields.iter().any(|f| f.ty.is_ref()),
             is_named: !is_implicit || fields.len() > 1,
             fields,
+            traits,
         }
     }
 
@@ -133,6 +140,7 @@ pub(crate) struct PreparedType {
     pub(crate) content: PreparedContent,
     pub(crate) is_copy: bool,
     pub(crate) is_params: bool,
+    pub(crate) traits: Vec<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -165,6 +173,7 @@ impl PreparedModule {
         map: &mut IndexMap<Span<String>, PreparedItem>,
         name: Span<String>,
         fields: Vec<PreparedField>,
+        traits: Vec<String>,
         is_implicit: bool,
     ) -> Result<(usize, Vec<usize>), Error> {
         assert!(!fields.is_empty());
@@ -186,8 +195,13 @@ impl PreparedModule {
                 Ok((o.index(), indexes))
             }
             Entry::Vacant(v) => {
-                v.insert(PreparedItem::new(name.clone(), fields.clone(), is_implicit));
-                Self::add(info, map, name, fields, is_implicit)
+                v.insert(PreparedItem::new(
+                    name.clone(),
+                    fields.clone(),
+                    traits.clone(),
+                    is_implicit,
+                ));
+                Self::add(info, map, name, fields, traits, is_implicit)
             }
         }
     }
@@ -197,14 +211,15 @@ impl PreparedModule {
         &mut self,
         name: Span<String>,
         fields: Vec<PreparedField>,
+        traits: Vec<String>,
         is_implicit: bool,
     ) -> Result<(usize, Vec<usize>), Error> {
-        let fuck = if fields.len() == 1 && is_implicit {
+        let n = if fields.len() == 1 && is_implicit {
             name.map(|_| fields[0].unwrapped_name())
         } else {
             name
         };
-        Self::add(&self.info, &mut self.rows, fuck, fields, is_implicit)
+        Self::add(&self.info, &mut self.rows, n, fields, traits, is_implicit)
     }
 
     #[allow(clippy::result_large_err)]
@@ -214,7 +229,14 @@ impl PreparedModule {
         fields: Vec<PreparedField>,
         is_implicit: bool,
     ) -> Result<(usize, Vec<usize>), Error> {
-        Self::add(&self.info, &mut self.params, name, fields, is_implicit)
+        Self::add(
+            &self.info,
+            &mut self.params,
+            name,
+            fields,
+            vec![],
+            is_implicit,
+        )
     }
 
     fn add_query(
@@ -298,10 +320,10 @@ fn prepare_type(
         ..
     } = ty
     {
-        let declared = types
-            .iter()
-            .find(|it| it.name.value == pg_ty.name())
-            .map_or(&[] as &[NullableIdent], |it| it.fields.as_slice());
+        let type_annotation = types.iter().find(|it| it.name.value == pg_ty.name());
+        let declared = type_annotation.map_or(&[] as &[NullableIdent], |it| it.fields.as_slice());
+        let traits = type_annotation.map_or_else(Vec::new, |it| it.traits.clone());
+
         let content = match pg_ty.kind() {
             Kind::Enum(variants) => {
                 PreparedContent::Enum(variants.clone().into_iter().map(Ident::new).collect())
@@ -329,6 +351,7 @@ fn prepare_type(
             content,
             is_copy: *is_copy,
             is_params: *is_params,
+            traits,
         })
     } else {
         None
@@ -390,8 +413,11 @@ fn prepare_query(
         .prepare(&sql_str)
         .map_err(|e| Error::new_db_err(&e, module_info, &sql_span, &name))?;
 
-    let (nullable_params_fields, params_name) = param.name_and_fields(types, &name, Some("Params"));
-    let (nullable_row_fields, row_name) = row.name_and_fields(types, &name, None);
+    let (nullable_params_fields, _, params_name) =
+        param.name_and_fields(types, &name, Some("Params"));
+
+    let (nullable_row_fields, traits, row_name) = row.name_and_fields(types, &name, None);
+
     let params_fields = {
         let stmt_params = stmt.params();
         let params = bind_params
@@ -457,13 +483,15 @@ fn prepare_query(
     let row_idx = if row_fields.is_empty() {
         None
     } else {
-        Some(module.add_row(row_name, row_fields, row.is_implicit())?)
+        Some(module.add_row(row_name, row_fields, traits, row.is_implicit())?)
     };
+
     let param_idx = if params_fields.is_empty() {
         None
     } else {
         Some(module.add_param(params_name, params_fields, param.is_implicit())?)
     };
+
     module.add_query(name.clone(), comments, param_idx, row_idx, sql_str);
 
     Ok(())

--- a/clorinde/src/prepare_queries.rs
+++ b/clorinde/src/prepare_queries.rs
@@ -214,12 +214,12 @@ impl PreparedModule {
         traits: Vec<String>,
         is_implicit: bool,
     ) -> Result<(usize, Vec<usize>), Error> {
-        let n = if fields.len() == 1 && is_implicit {
+        let nom = if fields.len() == 1 && is_implicit {
             name.map(|_| fields[0].unwrapped_name())
         } else {
             name
         };
-        Self::add(&self.info, &mut self.rows, n, fields, traits, is_implicit)
+        Self::add(&self.info, &mut self.rows, nom, fields, traits, is_implicit)
     }
 
     #[allow(clippy::result_large_err)]

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -71,6 +71,16 @@ See the [custom_types](https://github.com/halcyonnouveau/clorinde/blob/main/exam
 This ensures that your types can be properly serialized to and deserialized from PostgreSQL's wire format.
 ~~~
 
+## Derive traits
+You can specify `#[derive]` traits for generated structs using this field.
+
+```toml
+[types]
+derive-traits = ["Default", "serde::Deserialize"]
+```
+
+This will add the `Default` and `serde::Deserialize` traits to **all** structs. If you only want them added to specific structs, see this section in ["Type annotations"](/writing_queries/type_annotations.html#derive-traits).
+
 ## Static files
 The `static` field allows you to copy or link files into your generated crate directory. This is useful for including files like licenses, build configurations, or other assets that should persist across code generation.
 

--- a/docs/src/writing_queries/type_annotations.md
+++ b/docs/src/writing_queries/type_annotations.md
@@ -21,6 +21,16 @@ This will define a struct named `Author` containing typed fields for the `name` 
 Type annotations are declared with this token: `--:`
 ```
 
+## Derive traits
+You can specify additional `#[derive]` traits for the generated struct by declaring them after the type annotation.
+
+```sql
+--: Author(age?) : Default, serde::Deserialize
+
+--! authors : Author
+SELECT name, age FROM Authors;
+```
+
 ## Inline types
 You can also define type inline if you don't plan on reusing them across multiple queries:
 

--- a/examples/basic_async/basic_async_codegen/src/queries/module_2.rs
+++ b/examples/basic_async/basic_async_codegen/src/queries/module_2.rs
@@ -4,27 +4,27 @@
 pub struct AuthorNameStartingWithParams<T1: crate::StringSql> {
     pub start_str: T1,
 }
-#[derive(Debug, Clone, PartialEq, Hash)]
-pub struct Author {
+#[derive(Debug, Clone, PartialEq)]
+pub struct Authors {
     pub id: i32,
     pub name: String,
     pub country: String,
     pub dob: crate::types::time::Date,
 }
-pub struct AuthorBorrowed<'a> {
+pub struct AuthorsBorrowed<'a> {
     pub id: i32,
     pub name: &'a str,
     pub country: &'a str,
     pub dob: crate::types::time::Date,
 }
-impl<'a> From<AuthorBorrowed<'a>> for Author {
+impl<'a> From<AuthorsBorrowed<'a>> for Authors {
     fn from(
-        AuthorBorrowed {
+        AuthorsBorrowed {
             id,
             name,
             country,
             dob,
-        }: AuthorBorrowed<'a>,
+        }: AuthorsBorrowed<'a>,
     ) -> Self {
         Self {
             id,
@@ -88,19 +88,19 @@ impl<'a> From<SelectTranslationsBorrowed<'a>> for SelectTranslations {
 }
 use crate::client::async_::GenericClient;
 use futures::{self, StreamExt, TryStreamExt};
-pub struct AuthorQuery<'c, 'a, 's, C: GenericClient, T, const N: usize> {
+pub struct AuthorsQuery<'c, 'a, 's, C: GenericClient, T, const N: usize> {
     client: &'c C,
     params: [&'a (dyn postgres_types::ToSql + Sync); N],
     stmt: &'s mut crate::client::async_::Stmt,
-    extractor: fn(&tokio_postgres::Row) -> AuthorBorrowed,
-    mapper: fn(AuthorBorrowed) -> T,
+    extractor: fn(&tokio_postgres::Row) -> AuthorsBorrowed,
+    mapper: fn(AuthorsBorrowed) -> T,
 }
-impl<'c, 'a, 's, C, T: 'c, const N: usize> AuthorQuery<'c, 'a, 's, C, T, N>
+impl<'c, 'a, 's, C, T: 'c, const N: usize> AuthorsQuery<'c, 'a, 's, C, T, N>
 where
     C: GenericClient,
 {
-    pub fn map<R>(self, mapper: fn(AuthorBorrowed) -> R) -> AuthorQuery<'c, 'a, 's, C, R, N> {
-        AuthorQuery {
+    pub fn map<R>(self, mapper: fn(AuthorsBorrowed) -> R) -> AuthorsQuery<'c, 'a, 's, C, R, N> {
+        AuthorsQuery {
             client: self.client,
             params: self.params,
             stmt: self.stmt,
@@ -365,18 +365,18 @@ impl AuthorsStmt {
     pub fn bind<'c, 'a, 's, C: GenericClient>(
         &'s mut self,
         client: &'c C,
-    ) -> AuthorQuery<'c, 'a, 's, C, Author, 0> {
-        AuthorQuery {
+    ) -> AuthorsQuery<'c, 'a, 's, C, Authors, 0> {
+        AuthorsQuery {
             client,
             params: [],
             stmt: &mut self.0,
-            extractor: |row| AuthorBorrowed {
+            extractor: |row| AuthorsBorrowed {
                 id: row.get(0),
                 name: row.get(1),
                 country: row.get(2),
                 dob: row.get(3),
             },
-            mapper: |it| Author::from(it),
+            mapper: |it| Authors::from(it),
         }
     }
 }

--- a/examples/basic_async/basic_async_codegen/src/queries/module_2.rs
+++ b/examples/basic_async/basic_async_codegen/src/queries/module_2.rs
@@ -4,27 +4,27 @@
 pub struct AuthorNameStartingWithParams<T1: crate::StringSql> {
     pub start_str: T1,
 }
-#[derive(Debug, Clone, PartialEq)]
-pub struct Authors {
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct Author {
     pub id: i32,
     pub name: String,
     pub country: String,
     pub dob: crate::types::time::Date,
 }
-pub struct AuthorsBorrowed<'a> {
+pub struct AuthorBorrowed<'a> {
     pub id: i32,
     pub name: &'a str,
     pub country: &'a str,
     pub dob: crate::types::time::Date,
 }
-impl<'a> From<AuthorsBorrowed<'a>> for Authors {
+impl<'a> From<AuthorBorrowed<'a>> for Author {
     fn from(
-        AuthorsBorrowed {
+        AuthorBorrowed {
             id,
             name,
             country,
             dob,
-        }: AuthorsBorrowed<'a>,
+        }: AuthorBorrowed<'a>,
     ) -> Self {
         Self {
             id,
@@ -88,19 +88,19 @@ impl<'a> From<SelectTranslationsBorrowed<'a>> for SelectTranslations {
 }
 use crate::client::async_::GenericClient;
 use futures::{self, StreamExt, TryStreamExt};
-pub struct AuthorsQuery<'c, 'a, 's, C: GenericClient, T, const N: usize> {
+pub struct AuthorQuery<'c, 'a, 's, C: GenericClient, T, const N: usize> {
     client: &'c C,
     params: [&'a (dyn postgres_types::ToSql + Sync); N],
     stmt: &'s mut crate::client::async_::Stmt,
-    extractor: fn(&tokio_postgres::Row) -> AuthorsBorrowed,
-    mapper: fn(AuthorsBorrowed) -> T,
+    extractor: fn(&tokio_postgres::Row) -> AuthorBorrowed,
+    mapper: fn(AuthorBorrowed) -> T,
 }
-impl<'c, 'a, 's, C, T: 'c, const N: usize> AuthorsQuery<'c, 'a, 's, C, T, N>
+impl<'c, 'a, 's, C, T: 'c, const N: usize> AuthorQuery<'c, 'a, 's, C, T, N>
 where
     C: GenericClient,
 {
-    pub fn map<R>(self, mapper: fn(AuthorsBorrowed) -> R) -> AuthorsQuery<'c, 'a, 's, C, R, N> {
-        AuthorsQuery {
+    pub fn map<R>(self, mapper: fn(AuthorBorrowed) -> R) -> AuthorQuery<'c, 'a, 's, C, R, N> {
+        AuthorQuery {
             client: self.client,
             params: self.params,
             stmt: self.stmt,
@@ -365,18 +365,18 @@ impl AuthorsStmt {
     pub fn bind<'c, 'a, 's, C: GenericClient>(
         &'s mut self,
         client: &'c C,
-    ) -> AuthorsQuery<'c, 'a, 's, C, Authors, 0> {
-        AuthorsQuery {
+    ) -> AuthorQuery<'c, 'a, 's, C, Author, 0> {
+        AuthorQuery {
             client,
             params: [],
             stmt: &mut self.0,
-            extractor: |row| AuthorsBorrowed {
+            extractor: |row| AuthorBorrowed {
                 id: row.get(0),
                 name: row.get(1),
                 country: row.get(2),
                 dob: row.get(3),
             },
-            mapper: |it| Authors::from(it),
+            mapper: |it| Author::from(it),
         }
     }
 }

--- a/examples/basic_async/queries/module_2.sql
+++ b/examples/basic_async/queries/module_2.sql
@@ -1,4 +1,6 @@
---! authors
+--: Author() : Hash
+
+--! authors : Author
 SELECT
     *
 FROM
@@ -45,4 +47,3 @@ SELECT
     Translations
 FROM
     Book;
-

--- a/examples/basic_async/queries/module_2.sql
+++ b/examples/basic_async/queries/module_2.sql
@@ -1,6 +1,4 @@
---: Author() : Hash
-
---! authors : Author
+--! authors
 SELECT
     *
 FROM

--- a/examples/custom_types/clorinde.toml
+++ b/examples/custom_types/clorinde.toml
@@ -1,8 +1,12 @@
+serialize = true
 static = ["kafstel.txt"]
 use-workspace-deps = "../../Cargo.toml"
 
 [package]
 name = "custom_types_codegen"
+
+[types]
+derive-traits = ["Hash", "serde::Deserialize"]
 
 [types.crates]
 ctypes = { path = "../ctypes" }

--- a/examples/custom_types/ctypes/Cargo.toml
+++ b/examples/custom_types/ctypes/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-
 postgres-protocol = "0.6.7"
 postgres-types = "0.2.8"
 time = "0.3.37"
 bytes = "1.9.0"
+serde = { version = "1.0.217", features = ["derive"] }

--- a/examples/custom_types/ctypes/src/date.rs
+++ b/examples/custom_types/ctypes/src/date.rs
@@ -5,9 +5,10 @@ use std::error::Error;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// A wrapper that can be used to represent infinity with `Type::Date` types.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum Date {
     /// Represents `infinity`, a date that is later than all other dates.
+    #[default]
     PosInfinity,
     /// Represents `-infinity`, a date that is earlier than all other dates.
     NegInfinity,

--- a/examples/custom_types/custom_types_codegen/Cargo.toml
+++ b/examples/custom_types/custom_types_codegen/Cargo.toml
@@ -30,10 +30,12 @@ postgres_range = { version = "0.11.1", features = ["with-chrono-0_4"] }
 # TIME, DATE, TIMESTAMP or TIMESTAMPZ
 chrono = { workspace = true, optional = true }
 time = { workspace = true, optional = true }
+# JSON or JSONB
+serde = { version = "1.0.217", features = ["derive"] }
 
 ## Async client dependencies
 # Postgres async client
-tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-time-0_3"] }
+tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-time-0_3", "with-serde_json-1"] }
 # Async utils
 futures = "0.3.31"
 

--- a/examples/custom_types/custom_types_codegen/src/types.rs
+++ b/examples/custom_types/custom_types_codegen/src/types.rs
@@ -14,7 +14,7 @@ pub mod time {
     pub type Date = time::Date;
     pub type Time = time::Time;
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum SpongeBobCharacter {
     Bob,
@@ -94,7 +94,9 @@ impl<'a> postgres_types::FromSql<'a> for SpongeBobCharacter {
         }
     }
 }
-#[derive(Debug, postgres_types::FromSql, Clone, PartialEq)]
+#[derive(
+    serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq, Hash, serde::Deserialize,
+)]
 #[postgres(name = "voiceactor")]
 pub struct Voiceactor {
     #[postgres(name = "name")]

--- a/examples/custom_types/queries/module_2.sql
+++ b/examples/custom_types/queries/module_2.sql
@@ -45,4 +45,3 @@ SELECT
     Translations
 FROM
     Book;
-

--- a/examples/custom_types/queries/module_2.sql
+++ b/examples/custom_types/queries/module_2.sql
@@ -1,4 +1,6 @@
---! authors
+--: Author() : Default
+
+--! authors : Author
 SELECT
     *
 FROM

--- a/tests/codegen/queries/named.sql
+++ b/tests/codegen/queries/named.sql
@@ -3,7 +3,7 @@
 --: NamedParams(price?)
 
 --! new_named_visible NamedParams: Id
-INSERT INTO named (name, price, show) VALUES (:name, :price, true) RETURNING id ; 
+INSERT INTO named (name, price, show) VALUES (:name, :price, true) RETURNING id ;
 --! new_named_hidden NamedParams: Id
 INSERT INTO named (price, name, show) VALUES (:price, :name, false) RETURNING id;
 --! named: Named

--- a/tests/codegen/queries/nullity.sql
+++ b/tests/codegen/queries/nullity.sql
@@ -3,6 +3,6 @@
 --: nullity_composite(jsons?[?])
 
 --! new_nullity NullityParams
-INSERT INTO nullity(texts, name, composite) VALUES (:texts, :name, :composite); 
+INSERT INTO nullity(texts, name, composite) VALUES (:texts, :name, :composite);
 --! nullity: Nullity
 SELECT * FROM nullity;

--- a/tests/integration/fixtures/codegen/examples.toml
+++ b/tests/integration/fixtures/codegen/examples.toml
@@ -33,3 +33,4 @@ destination = "custom_types_codegen"
 async = true
 run = true
 config = true
+derive_ser = true


### PR DESCRIPTION
resolves #56.

adds ability to specify derive traits on generated row struct through:

- `types.derive-traits` config: adds to all structs.
```toml
[types]
derive-traits = ["Hash", "serde::Deserialize"]
```

- Type annotations: adds to that specific type.
```sql
--: Author() : Hash, serde::Deserialize

--! list_authors : Author
select * from Author;
```