### PR TITLE
fix(codegen): make "chrono" and "time" features mutually exclusive

### DIFF
--- a/benches/generated/src/types.rs
+++ b/benches/generated/src/types.rs
@@ -7,7 +7,7 @@ pub mod time {
     pub type Date = chrono::NaiveDate;
     pub type Time = chrono::NaiveTime;
 }
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", not(feature = "chrono")))]
 pub mod time {
     pub type Timestamp = time::PrimitiveDateTime;
     pub type TimestampTz = time::OffsetDateTime;

--- a/clorinde/src/codegen/types.rs
+++ b/clorinde/src/codegen/types.rs
@@ -23,7 +23,7 @@ pub(crate) fn gen_type_modules(
             pub type Date = chrono::NaiveDate;
             pub type Time = chrono::NaiveTime;
         }
-        #[cfg(feature = "time")]
+        #[cfg(all(feature = "time", not(feature = "chrono")))]
         pub mod time {
             pub type Timestamp = time::PrimitiveDateTime;
             pub type TimestampTz = time::OffsetDateTime;

--- a/examples/auto_build/auto_build_codegen/src/types.rs
+++ b/examples/auto_build/auto_build_codegen/src/types.rs
@@ -7,7 +7,7 @@ pub mod time {
     pub type Date = chrono::NaiveDate;
     pub type Time = chrono::NaiveTime;
 }
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", not(feature = "chrono")))]
 pub mod time {
     pub type Timestamp = time::PrimitiveDateTime;
     pub type TimestampTz = time::OffsetDateTime;

--- a/examples/basic_async/basic_async_codegen/src/types.rs
+++ b/examples/basic_async/basic_async_codegen/src/types.rs
@@ -7,7 +7,7 @@ pub mod time {
     pub type Date = chrono::NaiveDate;
     pub type Time = chrono::NaiveTime;
 }
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", not(feature = "chrono")))]
 pub mod time {
     pub type Timestamp = time::PrimitiveDateTime;
     pub type TimestampTz = time::OffsetDateTime;

--- a/examples/basic_async_wasm/basic_async_wasm_codegen/src/types.rs
+++ b/examples/basic_async_wasm/basic_async_wasm_codegen/src/types.rs
@@ -7,7 +7,7 @@ pub mod time {
     pub type Date = chrono::NaiveDate;
     pub type Time = chrono::NaiveTime;
 }
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", not(feature = "chrono")))]
 pub mod time {
     pub type Timestamp = time::PrimitiveDateTime;
     pub type TimestampTz = time::OffsetDateTime;

--- a/examples/basic_sync/basic_sync_codegen/src/types.rs
+++ b/examples/basic_sync/basic_sync_codegen/src/types.rs
@@ -7,7 +7,7 @@ pub mod time {
     pub type Date = chrono::NaiveDate;
     pub type Time = chrono::NaiveTime;
 }
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", not(feature = "chrono")))]
 pub mod time {
     pub type Timestamp = time::PrimitiveDateTime;
     pub type TimestampTz = time::OffsetDateTime;

--- a/examples/custom_types/custom_types_codegen/src/types.rs
+++ b/examples/custom_types/custom_types_codegen/src/types.rs
@@ -7,7 +7,7 @@ pub mod time {
     pub type Date = chrono::NaiveDate;
     pub type Time = chrono::NaiveTime;
 }
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", not(feature = "chrono")))]
 pub mod time {
     pub type Timestamp = time::PrimitiveDateTime;
     pub type TimestampTz = time::OffsetDateTime;

--- a/tests/codegen/codegen/src/types.rs
+++ b/tests/codegen/codegen/src/types.rs
@@ -7,7 +7,7 @@ pub mod time {
     pub type Date = chrono::NaiveDate;
     pub type Time = chrono::NaiveTime;
 }
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", not(feature = "chrono")))]
 pub mod time {
     pub type Timestamp = time::PrimitiveDateTime;
     pub type TimestampTz = time::OffsetDateTime;


### PR DESCRIPTION
The following generated code block breaks the rust-analyzer (for me):

```rust
#[cfg(feature = "time")]
pub mod time {
    pub type Timestamp = time::PrimitiveDateTime;
    pub type TimestampTz = time::OffsetDateTime;
    pub type Date = time::Date;
    pub type Time = time::Time;
}
```

And I don't see any possilbe issues with changing it to have the same kind of config as chrono.