### PR TITLE
feat: allow custom field attributes in type mappings

### DIFF
--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -94,20 +94,29 @@ fn gen_row_structs(
         .map(|t| syn::parse_str::<proc_macro2::TokenStream>(t).unwrap_or_else(|_| quote!()));
 
     // Generate field attributes if any
-    let fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_ty.iter()).map(|((field, name), ty)| {
-        let attrs = field.attributes.iter().map(|attr| {
-            syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
-        }).collect::<Vec<_>>();
-        
-        if attrs.is_empty() {
-            quote! { pub #name: #ty }
-        } else {
-            quote! { 
-                #(#[#attrs])*
-                pub #name: #ty 
+    let fields_with_attrs = fields
+        .iter()
+        .zip(fields_name.iter())
+        .zip(fields_ty.iter())
+        .map(|((field, name), ty)| {
+            let attrs = field
+                .attributes
+                .iter()
+                .map(|attr| {
+                    syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
+                })
+                .collect::<Vec<_>>();
+
+            if attrs.is_empty() {
+                quote! { pub #name: #ty }
+            } else {
+                quote! {
+                    #(#[#attrs])*
+                    pub #name: #ty
+                }
             }
-        }
-    }).collect::<Vec<_>>();
+        })
+        .collect::<Vec<_>>();
 
     let main_struct = quote! {
         #[derive(#ser_attr Debug, Clone, PartialEq #copy_attr #(,#trait_attrs)*)]
@@ -127,21 +136,31 @@ fn gen_row_structs(
         let field_assignments = fields.iter().map(|f| f.owning_assign());
 
         // Generate borrowed field attributes if any
-        let borrowed_fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(borrowed_fields_ty.iter()).map(|((field, name), ty)| {
-            let attrs = field.attributes.iter().map(|attr| {
-                syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
-            }).collect::<Vec<_>>();
-            
-            if attrs.is_empty() {
-                quote! { pub #name: #ty }
-            } else {
-                quote! { 
-                    #(#[#attrs])*
-                    pub #name: #ty 
+        let borrowed_fields_with_attrs = fields
+            .iter()
+            .zip(fields_name.iter())
+            .zip(borrowed_fields_ty.iter())
+            .map(|((field, name), ty)| {
+                let attrs = field
+                    .attributes
+                    .iter()
+                    .map(|attr| {
+                        syn::parse_str::<proc_macro2::TokenStream>(attr)
+                            .unwrap_or_else(|_| quote!())
+                    })
+                    .collect::<Vec<_>>();
+
+                if attrs.is_empty() {
+                    quote! { pub #name: #ty }
+                } else {
+                    quote! {
+                        #(#[#attrs])*
+                        pub #name: #ty
+                    }
                 }
-            }
-        }).collect::<Vec<_>>();
-        
+            })
+            .collect::<Vec<_>>();
+
         quote! {
             pub struct #borrowed_name<'a> {
                 #(#borrowed_fields_with_attrs,)*

--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -93,10 +93,26 @@ fn gen_row_structs(
         .chain(derive_traits.iter())
         .map(|t| syn::parse_str::<proc_macro2::TokenStream>(t).unwrap_or_else(|_| quote!()));
 
+    // Generate field attributes if any
+    let fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_ty.iter()).map(|((field, name), ty)| {
+        let attrs = field.attributes.iter().map(|attr| {
+            syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
+        }).collect::<Vec<_>>();
+        
+        if attrs.is_empty() {
+            quote! { pub #name: #ty }
+        } else {
+            quote! { 
+                #(#[#attrs])*
+                pub #name: #ty 
+            }
+        }
+    }).collect::<Vec<_>>();
+
     let main_struct = quote! {
         #[derive(#ser_attr Debug, Clone, PartialEq #copy_attr #(,#trait_attrs)*)]
         pub struct #name_ident {
-            #(pub #fields_name: #fields_ty,)*
+            #(#fields_with_attrs,)*
         }
     };
 
@@ -110,9 +126,25 @@ fn gen_row_structs(
 
         let field_assignments = fields.iter().map(|f| f.owning_assign());
 
+        // Generate borrowed field attributes if any
+        let borrowed_fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(borrowed_fields_ty.iter()).map(|((field, name), ty)| {
+            let attrs = field.attributes.iter().map(|attr| {
+                syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
+            }).collect::<Vec<_>>();
+            
+            if attrs.is_empty() {
+                quote! { pub #name: #ty }
+            } else {
+                quote! { 
+                    #(#[#attrs])*
+                    pub #name: #ty 
+                }
+            }
+        }).collect::<Vec<_>>();
+        
         quote! {
             pub struct #borrowed_name<'a> {
-                #(pub #fields_name: #borrowed_fields_ty,)*
+                #(#borrowed_fields_with_attrs,)*
             }
 
             impl<'a> From<#borrowed_name<'a>> for #name_ident {

--- a/clorinde/src/codegen/types.rs
+++ b/clorinde/src/codegen/types.rs
@@ -155,24 +155,35 @@ fn gen_custom_type(
                 .collect();
 
             // Generate field attributes if any
-            let fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_ty.iter()).zip(fields_original_name.iter()).map(|(((field, name), ty), original_name)| {
-                let field_attrs = field.attributes.iter().map(|attr| {
-                    syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
-                }).collect::<Vec<_>>();
-                
-                if field_attrs.is_empty() {
-                    quote! {
-                        #[postgres(name = #original_name)]
-                        pub #name: #ty
+            let fields_with_attrs = fields
+                .iter()
+                .zip(fields_name.iter())
+                .zip(fields_ty.iter())
+                .zip(fields_original_name.iter())
+                .map(|(((field, name), ty), original_name)| {
+                    let field_attrs = field
+                        .attributes
+                        .iter()
+                        .map(|attr| {
+                            syn::parse_str::<proc_macro2::TokenStream>(attr)
+                                .unwrap_or_else(|_| quote!())
+                        })
+                        .collect::<Vec<_>>();
+
+                    if field_attrs.is_empty() {
+                        quote! {
+                            #[postgres(name = #original_name)]
+                            pub #name: #ty
+                        }
+                    } else {
+                        quote! {
+                            #[postgres(name = #original_name)]
+                            #(#[#field_attrs])*
+                            pub #name: #ty
+                        }
                     }
-                } else {
-                    quote! {
-                        #[postgres(name = #original_name)]
-                        #(#[#field_attrs])*
-                        pub #name: #ty
-                    }
-                }
-            }).collect::<Vec<_>>();
+                })
+                .collect::<Vec<_>>();
 
             let struct_def = quote! {
                 #[derive(#ser_attr Debug, postgres_types::FromSql, #copy_attr Clone, PartialEq #(,#trait_attrs)*)]
@@ -197,20 +208,30 @@ fn gen_custom_type(
                 let field_assignments = fields.iter().map(|p| p.owning_assign());
 
                 // Generate borrowed field attributes if any
-                let borrowed_fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_brw.iter()).map(|((field, name), ty)| {
-                    let field_attrs = field.attributes.iter().map(|attr| {
-                        syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
-                    }).collect::<Vec<_>>();
-                    
-                    if field_attrs.is_empty() {
-                        quote! { pub #name: #ty }
-                    } else {
-                        quote! { 
-                            #(#[#field_attrs])*
-                            pub #name: #ty 
+                let borrowed_fields_with_attrs = fields
+                    .iter()
+                    .zip(fields_name.iter())
+                    .zip(fields_brw.iter())
+                    .map(|((field, name), ty)| {
+                        let field_attrs = field
+                            .attributes
+                            .iter()
+                            .map(|attr| {
+                                syn::parse_str::<proc_macro2::TokenStream>(attr)
+                                    .unwrap_or_else(|_| quote!())
+                            })
+                            .collect::<Vec<_>>();
+
+                        if field_attrs.is_empty() {
+                            quote! { pub #name: #ty }
+                        } else {
+                            quote! {
+                                #(#[#field_attrs])*
+                                pub #name: #ty
+                            }
                         }
-                    }
-                }).collect::<Vec<_>>();
+                    })
+                    .collect::<Vec<_>>();
 
                 let borrowed_struct = quote! {
                     #[derive(Debug)]
@@ -246,20 +267,30 @@ fn gen_custom_type(
                     };
 
                     // Generate params field attributes if any
-                    let params_fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_ty.iter()).map(|((field, name), ty)| {
-                        let field_attrs = field.attributes.iter().map(|attr| {
-                            syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
-                        }).collect::<Vec<_>>();
-                        
-                        if field_attrs.is_empty() {
-                            quote! { pub #name: #ty }
-                        } else {
-                            quote! { 
-                                #(#[#field_attrs])*
-                                pub #name: #ty 
+                    let params_fields_with_attrs = fields
+                        .iter()
+                        .zip(fields_name.iter())
+                        .zip(fields_ty.iter())
+                        .map(|((field, name), ty)| {
+                            let field_attrs = field
+                                .attributes
+                                .iter()
+                                .map(|attr| {
+                                    syn::parse_str::<proc_macro2::TokenStream>(attr)
+                                        .unwrap_or_else(|_| quote!())
+                                })
+                                .collect::<Vec<_>>();
+
+                            if field_attrs.is_empty() {
+                                quote! { pub #name: #ty }
+                            } else {
+                                quote! {
+                                    #(#[#field_attrs])*
+                                    pub #name: #ty
+                                }
                             }
-                        }
-                    }).collect::<Vec<_>>();
+                        })
+                        .collect::<Vec<_>>();
 
                     quote! {
                         #[derive(Debug #derive)]

--- a/clorinde/src/codegen/types.rs
+++ b/clorinde/src/codegen/types.rs
@@ -154,14 +154,31 @@ fn gen_custom_type(
                 .map(|p| syn::parse_str::<syn::Type>(&p.own_struct(ctx)).unwrap())
                 .collect();
 
+            // Generate field attributes if any
+            let fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_ty.iter()).zip(fields_original_name.iter()).map(|(((field, name), ty), original_name)| {
+                let field_attrs = field.attributes.iter().map(|attr| {
+                    syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
+                }).collect::<Vec<_>>();
+                
+                if field_attrs.is_empty() {
+                    quote! {
+                        #[postgres(name = #original_name)]
+                        pub #name: #ty
+                    }
+                } else {
+                    quote! {
+                        #[postgres(name = #original_name)]
+                        #(#[#field_attrs])*
+                        pub #name: #ty
+                    }
+                }
+            }).collect::<Vec<_>>();
+
             let struct_def = quote! {
                 #[derive(#ser_attr Debug, postgres_types::FromSql, #copy_attr Clone, PartialEq #(,#trait_attrs)*)]
                 #[postgres(name = #name_lit)]
                 pub struct #struct_name_ident {
-                    #(
-                        #[postgres(name = #fields_original_name)]
-                        pub #fields_name: #fields_ty,
-                    )*
+                    #(#fields_with_attrs,)*
                 }
             };
 
@@ -179,10 +196,26 @@ fn gen_custom_type(
 
                 let field_assignments = fields.iter().map(|p| p.owning_assign());
 
+                // Generate borrowed field attributes if any
+                let borrowed_fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_brw.iter()).map(|((field, name), ty)| {
+                    let field_attrs = field.attributes.iter().map(|attr| {
+                        syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
+                    }).collect::<Vec<_>>();
+                    
+                    if field_attrs.is_empty() {
+                        quote! { pub #name: #ty }
+                    } else {
+                        quote! { 
+                            #(#[#field_attrs])*
+                            pub #name: #ty 
+                        }
+                    }
+                }).collect::<Vec<_>>();
+
                 let borrowed_struct = quote! {
                     #[derive(Debug)]
                     pub struct #struct_name_borrowed_ident<'a> {
-                        #(pub #fields_name: #fields_brw,)*
+                        #(#borrowed_fields_with_attrs,)*
                     }
 
                     impl<'a> From<#struct_name_borrowed_ident<'a>> for #struct_name_ident {
@@ -212,10 +245,26 @@ fn gen_custom_type(
                         quote!()
                     };
 
+                    // Generate params field attributes if any
+                    let params_fields_with_attrs = fields.iter().zip(fields_name.iter()).zip(fields_ty.iter()).map(|((field, name), ty)| {
+                        let field_attrs = field.attributes.iter().map(|attr| {
+                            syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
+                        }).collect::<Vec<_>>();
+                        
+                        if field_attrs.is_empty() {
+                            quote! { pub #name: #ty }
+                        } else {
+                            quote! { 
+                                #(#[#field_attrs])*
+                                pub #name: #ty 
+                            }
+                        }
+                    }).collect::<Vec<_>>();
+
                     quote! {
                         #[derive(Debug #derive)]
                         pub struct #struct_name_params_ident<'a> {
-                            #(pub #fields_name: #fields_ty,)*
+                            #(#params_fields_with_attrs,)*
                         }
                     }
                 } else {

--- a/clorinde/src/config.rs
+++ b/clorinde/src/config.rs
@@ -193,7 +193,18 @@ pub enum TypeMapping {
         is_copy: bool,
         #[serde(default = "default_true", rename = "is-params")]
         is_params: bool,
+        #[serde(default, rename = "attributes")]
+        attributes: Vec<String>,
     },
+}
+
+impl TypeMapping {
+    pub fn get_attributes(&self) -> &[String] {
+        match self {
+            TypeMapping::Simple(_) => &[],
+            TypeMapping::Detailed { attributes, .. } => attributes,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/clorinde/src/prepare_queries.rs
+++ b/clorinde/src/prepare_queries.rs
@@ -70,6 +70,7 @@ pub struct PreparedField {
     pub(crate) ty: Rc<ClorindeType>,
     pub(crate) is_nullable: bool,
     pub(crate) is_inner_nullable: bool, // Vec only
+    pub(crate) attributes: Vec<String>, // Custom field attributes
 }
 
 impl PreparedField {
@@ -83,7 +84,13 @@ impl PreparedField {
             ty,
             is_nullable: nullity.is_some_and(|it| it.nullable),
             is_inner_nullable: nullity.is_some_and(|it| it.inner_nullable),
+            attributes: Vec::new(),
         }
+    }
+    
+    pub(crate) fn with_attributes(mut self, attributes: Vec<String>) -> Self {
+        self.attributes = attributes;
+        self
     }
 }
 
@@ -335,11 +342,20 @@ fn prepare_type(
                     .iter()
                     .map(|field| {
                         let nullity = declared.iter().find(|it| it.name.value == field.name());
+                        let ty = registrar.ref_of(field.type_());
+                        
+                        // Get any custom attributes for this field based on its type
+                        let attributes = if let Some(mapping) = registrar.config.get_type_mapping(field.type_()) {
+                            mapping.get_attributes().to_vec()
+                        } else {
+                            Vec::new()
+                        };
+                        
                         PreparedField::new(
                             field.name().to_string(),
-                            registrar.ref_of(field.type_()),
+                            ty, 
                             nullity,
-                        )
+                        ).with_attributes(attributes)
                     })
                     .collect(),
             ),
@@ -439,13 +455,24 @@ fn prepare_query(
                 .iter()
                 .find(|x| x.name.value == col_name.value);
             // Register type
-            param_fields.push(PreparedField::new(
-                col_name.value.clone(),
-                registrar
-                    .register(&col_name.value, &col_ty, &name, module_info)?
-                    .clone(),
-                nullity,
-            ));
+            let ty = registrar
+                .register(&col_name.value, &col_ty, &name, module_info)?
+                .clone();
+                
+            // Get any custom attributes for this field based on its type
+            let attributes = if let Some(mapping) = registrar.config.get_type_mapping(&col_ty) {
+                mapping.get_attributes().to_vec()
+            } else {
+                Vec::new()
+            };
+            
+            param_fields.push(
+                PreparedField::new(
+                    col_name.value.clone(),
+                    ty,
+                    nullity,
+                ).with_attributes(attributes)
+            );
         }
         param_fields
     };
@@ -471,11 +498,20 @@ fn prepare_query(
             let ty = registrar
                 .register(&col_name, col_ty, &name, module_info)?
                 .clone();
-            row_fields.push(PreparedField::new(
-                normalize_rust_name(&col_name),
-                ty,
-                nullity,
-            ));
+            // Get any custom attributes for this field based on its type
+            let attributes = if let Some(mapping) = registrar.config.get_type_mapping(col_ty) {
+                mapping.get_attributes().to_vec()
+            } else {
+                Vec::new()
+            };
+            
+            row_fields.push(
+                PreparedField::new(
+                    normalize_rust_name(&col_name),
+                    ty,
+                    nullity,
+                ).with_attributes(attributes)
+            );
         }
         row_fields
     };

--- a/clorinde/src/prepare_queries.rs
+++ b/clorinde/src/prepare_queries.rs
@@ -345,13 +345,12 @@ fn prepare_type(
                         let ty = registrar.ref_of(field.type_());
 
                         // Get any custom attributes for this field based on its type
-                        let attributes = if let Some(mapping) =
-                            registrar.get_type_mapping(field.type_())
-                        {
-                            mapping.get_attributes().to_vec()
-                        } else {
-                            Vec::new()
-                        };
+                        let attributes =
+                            if let Some(mapping) = registrar.get_type_mapping(field.type_()) {
+                                mapping.get_attributes().to_vec()
+                            } else {
+                                Vec::new()
+                            };
 
                         PreparedField::new(field.name().to_string(), ty, nullity)
                             .with_attributes(attributes)

--- a/clorinde/src/prepare_queries.rs
+++ b/clorinde/src/prepare_queries.rs
@@ -87,7 +87,7 @@ impl PreparedField {
             attributes: Vec::new(),
         }
     }
-    
+
     pub(crate) fn with_attributes(mut self, attributes: Vec<String>) -> Self {
         self.attributes = attributes;
         self
@@ -343,19 +343,18 @@ fn prepare_type(
                     .map(|field| {
                         let nullity = declared.iter().find(|it| it.name.value == field.name());
                         let ty = registrar.ref_of(field.type_());
-                        
+
                         // Get any custom attributes for this field based on its type
-                        let attributes = if let Some(mapping) = registrar.config.get_type_mapping(field.type_()) {
+                        let attributes = if let Some(mapping) =
+                            registrar.get_type_mapping(field.type_())
+                        {
                             mapping.get_attributes().to_vec()
                         } else {
                             Vec::new()
                         };
-                        
-                        PreparedField::new(
-                            field.name().to_string(),
-                            ty, 
-                            nullity,
-                        ).with_attributes(attributes)
+
+                        PreparedField::new(field.name().to_string(), ty, nullity)
+                            .with_attributes(attributes)
                     })
                     .collect(),
             ),
@@ -458,20 +457,16 @@ fn prepare_query(
             let ty = registrar
                 .register(&col_name.value, &col_ty, &name, module_info)?
                 .clone();
-                
+
             // Get any custom attributes for this field based on its type
-            let attributes = if let Some(mapping) = registrar.config.get_type_mapping(&col_ty) {
+            let attributes = if let Some(mapping) = registrar.get_type_mapping(&col_ty) {
                 mapping.get_attributes().to_vec()
             } else {
                 Vec::new()
             };
-            
+
             param_fields.push(
-                PreparedField::new(
-                    col_name.value.clone(),
-                    ty,
-                    nullity,
-                ).with_attributes(attributes)
+                PreparedField::new(col_name.value.clone(), ty, nullity).with_attributes(attributes),
             );
         }
         param_fields
@@ -499,18 +494,15 @@ fn prepare_query(
                 .register(&col_name, col_ty, &name, module_info)?
                 .clone();
             // Get any custom attributes for this field based on its type
-            let attributes = if let Some(mapping) = registrar.config.get_type_mapping(col_ty) {
+            let attributes = if let Some(mapping) = registrar.get_type_mapping(col_ty) {
                 mapping.get_attributes().to_vec()
             } else {
                 Vec::new()
             };
-            
+
             row_fields.push(
-                PreparedField::new(
-                    normalize_rust_name(&col_name),
-                    ty,
-                    nullity,
-                ).with_attributes(attributes)
+                PreparedField::new(normalize_rust_name(&col_name), ty, nullity)
+                    .with_attributes(attributes),
             );
         }
         row_fields

--- a/clorinde/src/type_registrar.rs
+++ b/clorinde/src/type_registrar.rs
@@ -333,7 +333,7 @@ impl TypeRegistrar {
             config,
         }
     }
-    
+
     /// Returns the type mapping for a specific type
     pub(crate) fn get_type_mapping(&self, ty: &Type) -> Option<&TypeMapping> {
         self.config.get_type_mapping(ty)

--- a/clorinde/src/type_registrar.rs
+++ b/clorinde/src/type_registrar.rs
@@ -333,6 +333,11 @@ impl TypeRegistrar {
             config,
         }
     }
+    
+    /// Returns the type mapping for a specific type
+    pub(crate) fn get_type_mapping(&self, ty: &Type) -> Option<&TypeMapping> {
+        self.config.get_type_mapping(ty)
+    }
 
     fn resolve_type(
         &mut self,
@@ -461,6 +466,7 @@ impl TypeRegistrar {
                     rust_type,
                     is_copy,
                     is_params,
+                    attributes: _,
                 } => Some((rust_type.to_string(), *is_copy, *is_params)),
             }
         } else {


### PR DESCRIPTION
  ## Custom Field Attributes for Type Mappings

  This PR implements a solution for issue #79 by adding the ability to define custom serialization
  attributes for fields based on their PostgreSQL type.

  ### Key Changes

  1. Add support for custom `attributes` field in `TypeMapping::Detailed`
  2. Add accessor method for type attributes in config
  3. Implement attributes in field generation for row structs and composite types
  4. Apply attributes to all borrowed structs where applicable

  ### Example Configuration

  Users can now customize the serialization of timestamp fields as follows:

  ```toml
  [types.mapping]
  "pg_catalog.timestamptz" = {
    rust-type = "crate::types::time::TimestampTz",
    attributes = [
      "serde(with = \"crate::serde_utils\")",
    ]
  }
```

 This configuration adds `#[serde(with = "crate::serde_utils")]` to any field of type timestamptz,
  providing greater control over serialization.