### PR TITLE
feat: support for directory-based SQL files mapped to module hierarchy

### DIFF
--- a/clorinde/src/read_queries.rs
+++ b/clorinde/src/read_queries.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -11,7 +12,10 @@ use crate::config::Config;
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleInfo {
     pub(crate) path: PathBuf,
+    // The name field contains just the file name without extension (e.g. "roles" for "roles.sql")
     pub(crate) name: String,
+    // Full module path with namespace (e.g. "users::roles" for "queries/users/roles.sql")
+    pub(crate) full_module_path: String,
     pub(crate) content: Arc<String>,
 }
 
@@ -27,7 +31,8 @@ impl From<&ModuleInfo> for NamedSource<Arc<String>> {
     }
 }
 
-/// Reads queries in the directory. Only .sql files are considered.
+/// Reads queries in the directory, recursively traversing subdirectories.
+/// Only .sql files are considered.
 /// If `config.ignore_underscore_files` is true, files with names prefixed with '_' are ignored.
 ///
 /// # Error
@@ -36,20 +41,52 @@ pub(crate) fn read_query_modules(
     dir_path: &Path,
     config: &Config,
 ) -> Result<Vec<ModuleInfo>, Error> {
+    // Using the recursive function but passing the same path for base and current
+    // to maintain backward compatibility
+    let modules_info = read_query_modules_recursive(dir_path, dir_path, config)?;
+    Ok(modules_info)
+}
+
+/// Recursively reads queries from a directory and its subdirectories.
+/// Maps the directory structure to module paths.
+fn read_query_modules_recursive(
+    base_dir: &Path,
+    current_dir: &Path,
+    config: &Config,
+) -> Result<Vec<ModuleInfo>, Error> {
     let mut modules_info = Vec::new();
-    for entry_result in std::fs::read_dir(dir_path).map_err(|err| Error {
+
+    // Determine the relative path from base_dir to current_dir
+    let relative_path = match current_dir.strip_prefix(base_dir) {
+        Ok(path) => path,
+        Err(_) => Path::new(""), // Fallback if prefix stripping fails
+    };
+
+    // Process entries in the current directory
+    for entry_result in std::fs::read_dir(current_dir).map_err(|err| Error {
         err,
-        path: dir_path.to_owned(),
+        path: current_dir.to_owned(),
     })? {
-        // Directory entry
         let entry = entry_result.map_err(|err| Error {
             err,
-            path: dir_path.to_owned(),
+            path: current_dir.to_owned(),
         })?;
         let path_buf = entry.path();
 
-        // Check we're dealing with a .sql file
-        if path_buf
+        if path_buf.is_dir() {
+            // Skip directories starting with underscore if configured to do so
+            if let Some(dir_name) = path_buf.file_name() {
+                if let Some(dir_name_str) = dir_name.to_str() {
+                    if config.ignore_underscore_files && dir_name_str.starts_with('_') {
+                        continue;
+                    }
+                }
+            }
+
+            // Recursively process subdirectory
+            let nested_modules = read_query_modules_recursive(base_dir, &path_buf, config)?;
+            modules_info.extend(nested_modules);
+        } else if path_buf
             .extension()
             .map(|extension| extension == "sql")
             .unwrap_or_default()
@@ -65,6 +102,7 @@ pub(crate) fn read_query_modules(
                 continue;
             }
 
+            // Get the basic module name from the file stem
             let module_name = path_buf
                 .file_stem()
                 .expect("is a file")
@@ -72,21 +110,75 @@ pub(crate) fn read_query_modules(
                 .expect("file name is valid utf8")
                 .to_string();
 
+            // Construct the full module path based on directory structure
+            let full_module_path = if relative_path.as_os_str().is_empty() {
+                // Root-level file
+                module_name.clone()
+            } else {
+                // Create a path that represents the module hierarchy
+                let rel_path_str = path_to_module_path(relative_path);
+                format!("{}::{}", rel_path_str, module_name)
+            };
+
             let file_contents = std::fs::read_to_string(&path_buf).map_err(|err| Error {
                 err,
-                path: dir_path.to_owned(),
+                path: current_dir.to_owned(),
             })?;
 
             modules_info.push(ModuleInfo {
                 path: path_buf,
                 name: module_name,
+                full_module_path,
                 content: Arc::new(file_contents),
             });
         }
     }
-    // Sort module for consistent codegen
-    modules_info.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // Sort modules for consistent codegen
+    modules_info.sort_by(|a, b| a.full_module_path.cmp(&b.full_module_path));
     Ok(modules_info)
+}
+
+/// Converts a Path to a module path string (directory separators to ::)
+fn path_to_module_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|comp| match comp {
+            std::path::Component::Normal(s) => s.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<&str>>()
+        .join("::")
+}
+
+/// Gets module hierarchy information for all modules
+pub(crate) fn build_module_hierarchy(
+    modules: &[ModuleInfo],
+) -> BTreeMap<String, Vec<(String, bool)>> {
+    let mut module_tree = BTreeMap::new();
+
+    for module in modules {
+        let path_components: Vec<&str> = module.full_module_path.split("::").collect();
+
+        // Add each level of the hierarchy
+        let mut current_path = Vec::new();
+        for (i, component) in path_components.iter().enumerate() {
+            current_path.push(*component);
+            let current_path_str = current_path.join("::");
+
+            if i < path_components.len() - 1 {
+                // This is a directory, not a leaf module
+                module_tree
+                    .entry(current_path_str)
+                    .or_insert_with(Vec::new)
+                    .push((
+                        path_components[i + 1].to_string(),
+                        i == path_components.len() - 2,
+                    ));
+            }
+        }
+    }
+
+    module_tree
 }
 
 pub(crate) mod error {


### PR DESCRIPTION
This change allows Clorinde to handle SQL files organized in subdirectories by recursively traversing the directory structure and mapping it to a corresponding module hierarchy in the generated Rust code.

For example, a file at `queries/users/roles.sql` will be compiled to `src/queries/users/roles.rs` and properly exposed through module hierarchy.

The implementation:
- Adds recursive directory traversal in read_queries.rs
- Tracks both the file name and full module path
- Generates appropriate mod.rs files for each directory level
- Converts directory separators to Rust module separators


