### PR TITLE
Add search_path option to Live action and set in Postgres client

### DIFF
--- a/clorinde/src/cli.rs
+++ b/clorinde/src/cli.rs
@@ -20,6 +20,10 @@ enum Action {
         /// Postgres url to the database
         url: String,
 
+        #[clap(long)]
+        /// Postgres search path to use for the queries
+        search_path: Option<String>,
+
         #[clap(flatten)]
         args: CommonArgs,
     },
@@ -124,8 +128,14 @@ pub fn run() -> Result<(), Error> {
     }
 
     match action {
-        Action::Live { url, .. } => {
+        Action::Live {
+            url, search_path, ..
+        } => {
             let mut client = conn::from_url(&url)?;
+            if let Some(search_path) = search_path.as_ref() {
+                conn::set_search_path(&mut client, search_path)?;
+            }
+
             gen_live(&mut client, cfg)?;
         }
         Action::Schema { schema_files, .. } => {

--- a/clorinde/src/conn.rs
+++ b/clorinde/src/conn.rs
@@ -18,6 +18,14 @@ pub fn clorinde_conn() -> Result<Client, Error> {
         .connect(NoTls)?)
 }
 
+// Sets the search path for the given client.
+pub fn set_search_path(client: &mut Client, search_path: &str) -> Result<(), Error> {
+    client
+        .execute(&format!("SET search_path TO {}", search_path), &[])
+        .map_err(Error::from)?;
+    Ok(())
+}
+
 pub(crate) mod error {
     use miette::Diagnostic;
 


### PR DESCRIPTION
This pull request introduces a new feature to allow specifying a custom PostgreSQL search path for queries in the `clorinde` CLI tool. The changes include adding a new `search_path` option, updating the handling of the `Action::Live` variant, and implementing a utility function to set the search path in the database client.

### Feature: Support for PostgreSQL search path

* **Added `search_path` option to `Action::Live`**: A new optional `search_path` parameter was introduced in the `Action::Live` variant of the CLI to enable users to specify a custom search path for PostgreSQL queries. (`clorinde/src/cli.rs`, [clorinde/src/cli.rsR23-R26](diffhunk://#diff-415929db97e3fa65c6902e0f9cb88ba0bb9df4bc8b5dcb65bc9755a7325370dcR23-R26))

* **Updated `run` function to handle `search_path`**: The `run` function now sets the search path for the PostgreSQL client if the `search_path` option is provided by the user. (`clorinde/src/cli.rs`, [clorinde/src/cli.rsL127-R138](diffhunk://#diff-415929db97e3fa65c6902e0f9cb88ba0bb9df4bc8b5dcb65bc9755a7325370dcL127-R138))

* **Implemented `set_search_path` utility function**: A new function, `set_search_path`, was added to the `conn` module to execute the SQL command for setting the search path on a PostgreSQL client. (`clorinde/src/conn.rs`, [clorinde/src/conn.rsR21-R28](diffhunk://#diff-c1565ce204733657042d494b5c7b7f736678a7abc0c1524961872ce71d192475R21-R28))