### PR TITLE
feat: add params-only mode to make bind() private

### DIFF
--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -407,7 +407,7 @@ fn gen_query_fn(
             };
 
             let bind_visibility =
-                if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
+                if config.params_only && param.as_ref().is_some_and(|p| p.is_named) {
                     quote! {} // No visibility modifier means private
                 } else {
                     quote! { pub }
@@ -434,7 +434,7 @@ fn gen_query_fn(
             let owning_call = syn::parse_str::<syn::Expr>(&field.owning_call(Some("it"))).unwrap();
 
             let bind_visibility =
-                if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
+                if config.params_only && param.as_ref().is_some_and(|p| p.is_named) {
                     quote! {} // No visibility modifier means private
                 } else {
                     quote! { pub }
@@ -465,8 +465,7 @@ fn gen_query_fn(
             })
             .collect();
 
-        let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named)
-        {
+        let bind_visibility = if config.params_only && param.as_ref().is_some_and(|p| p.is_named) {
             quote! {} // No visibility modifier means private
         } else {
             quote! { pub }

--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -306,6 +306,7 @@ fn gen_query_fn(
     module: &PreparedModule,
     query: &PreparedQuery,
     ctx: &GenCtx,
+    config: &Config,
 ) -> proc_macro2::TokenStream {
     let PreparedQuery {
         ident,
@@ -405,8 +406,14 @@ fn gen_query_fn(
                 |it| #path::from(it)
             };
 
+            let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
+                quote! {}  // No visibility modifier means private
+            } else {
+                quote! { pub }
+            };
+
             quote! {
-                pub fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
+                #bind_visibility fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
                     &'s mut self,
                     client: &'c #client_mut C,
                     #(#params_name: &'a #params_ty,)*
@@ -425,8 +432,14 @@ fn gen_query_fn(
             let field_type = syn::parse_str::<syn::Type>(&field.own_struct(ctx)).unwrap();
             let owning_call = syn::parse_str::<syn::Expr>(&field.owning_call(Some("it"))).unwrap();
 
+            let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
+                quote! {}  // No visibility modifier means private
+            } else {
+                quote! { pub }
+            };
+
             quote! {
-                pub fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
+                #bind_visibility fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
                     &'s mut self,
                     client: &'c #client_mut C,
                     #(#params_name: &'a #params_ty,)*
@@ -450,8 +463,14 @@ fn gen_query_fn(
             })
             .collect();
 
+        let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
+            quote! {}  // No visibility modifier means private
+        } else {
+            quote! { pub }
+        };
+
         quote! {
-            pub #fn_async fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
+            #bind_visibility #fn_async fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
                 &'s mut self,
                 client: &'c #client_mut C,
                 #(#params_name: &'a #params_ty,)*
@@ -642,7 +661,7 @@ fn gen_specific(
     }
 
     for query in module.queries.values() {
-        let query_tokens = gen_query_fn(module, query, &ctx);
+        let query_tokens = gen_query_fn(module, query, &ctx, config);
         tokens.extend(quote!(#query_tokens));
     }
 

--- a/clorinde/src/codegen/queries.rs
+++ b/clorinde/src/codegen/queries.rs
@@ -406,11 +406,12 @@ fn gen_query_fn(
                 |it| #path::from(it)
             };
 
-            let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
-                quote! {}  // No visibility modifier means private
-            } else {
-                quote! { pub }
-            };
+            let bind_visibility =
+                if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
+                    quote! {} // No visibility modifier means private
+                } else {
+                    quote! { pub }
+                };
 
             quote! {
                 #bind_visibility fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
@@ -432,11 +433,12 @@ fn gen_query_fn(
             let field_type = syn::parse_str::<syn::Type>(&field.own_struct(ctx)).unwrap();
             let owning_call = syn::parse_str::<syn::Expr>(&field.owning_call(Some("it"))).unwrap();
 
-            let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
-                quote! {}  // No visibility modifier means private
-            } else {
-                quote! { pub }
-            };
+            let bind_visibility =
+                if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
+                    quote! {} // No visibility modifier means private
+                } else {
+                    quote! { pub }
+                };
 
             quote! {
                 #bind_visibility fn bind<'c, 'a, 's, C: GenericClient, #(#traits_idents: #traits_bounds,)*>(
@@ -463,8 +465,9 @@ fn gen_query_fn(
             })
             .collect();
 
-        let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named) {
-            quote! {}  // No visibility modifier means private
+        let bind_visibility = if config.params_only && param.as_ref().map_or(false, |p| p.is_named)
+        {
+            quote! {} // No visibility modifier means private
         } else {
             quote! { pub }
         };

--- a/clorinde/src/config.rs
+++ b/clorinde/src/config.rs
@@ -33,6 +33,9 @@ pub struct Config {
     /// Container wait time in milliseconds after health check
     #[serde(rename = "container-wait")]
     pub container_wait: u64,
+    /// Make bind functions private to force usage of params() method
+    #[serde(rename = "params-only")]
+    pub params_only: bool,
 
     // Config file exclusive
     /// Custom type settings
@@ -80,6 +83,7 @@ impl Default for Config {
             r#async: true,
             serialize: false,
             ignore_underscore_files: false, // Default to false for backwards compatibility
+            params_only: false,
             types: Types {
                 crate_info: HashMap::new(),
                 mapping: HashMap::new(),
@@ -397,6 +401,12 @@ impl ConfigBuilder {
     /// Ignore query files prefixed with underscore
     pub fn ignore_underscore_files(mut self, ignore_underscore_files: bool) -> Self {
         self.config.ignore_underscore_files = ignore_underscore_files;
+        self
+    }
+
+    /// Make bind functions private to force usage of params() method
+    pub fn params_only(mut self, params_only: bool) -> Self {
+        self.config.params_only = params_only;
         self
     }
 


### PR DESCRIPTION
## Summary
- Adds a new `params-only` configuration option that makes the `bind()` method private
- Forces users to use the safer `params()` method with named parameter structs
- Prevents errors from incorrect parameter ordering in positional bind() calls

## Changes
- Added `params_only: bool` field to `Config` struct with default value `false`
- Added `params_only()` method to `ConfigBuilder`
- Modified code generation to conditionally set bind() visibility based on `params_only` flag
- When `params_only = true` and query has named parameters, bind() is generated as private