### PR TITLE
feat(breaking): allow config to specify entire generated cargo manifest

### DIFF
--- a/.rules
+++ b/.rules
@@ -23,8 +23,8 @@ Clorinde is a codegen tool that transforms PostgreSQL queries into type-safe Rus
 * `queries: PathBuf` - Directory containing SQL query files
 * `destination: PathBuf` - Where to write generated code
 * `sync: bool` and `async: bool` - Whether to generate sync/async variants
-* `types: Types` - Custom type mappings and crate dependencies
-* `package: Package` - Cargo.toml metadata for generated crate
+* `types: Types` - Custom type mappings for PostgreSQL types
+* `manifest: cargo_toml::Manifest` - Complete Cargo.toml configuration for generated crate
 
 The `Config` can be created from a TOML file via `Config::from_file()` or built programmatically using `Config::builder()`. Example:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cargo_toml"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +516,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "clorinde"
 version = "0.16.0"
 dependencies = [
+ "cargo_toml",
  "chumsky",
  "clap",
  "heck",

--- a/benches/generated/Cargo.toml
+++ b/benches/generated/Cargo.toml
@@ -1,34 +1,34 @@
 # This file was generated with `clorinde`. Do not modify.
+
 [package]
 name = "generated"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
+[dependencies.deadpool-postgres]
+version = "0.14.1"
+optional = true
+
+[dependencies.futures]
+version = "0.3.31"
+
+[dependencies.postgres]
+version = "0.19.10"
+
+[dependencies.postgres-protocol]
+version = "0.6.8"
+
+[dependencies.postgres-types]
+version = "0.2.9"
+features = ["derive"]
+
+[dependencies.tokio-postgres]
+version = "0.7.13"
+
 [features]
-default = ["deadpool"]
-deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js"]
-
 chrono = []
+deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
+default = ["deadpool"]
 time = []
-
-[dependencies]
-## Core dependencies
-# Postgres types
-postgres-types = { version = "0.2.9", features = ["derive"] }
-# Postgres interaction
-postgres-protocol = "0.6.8"
-
-# Postgres
-postgres = { version = "0.19.10", features = [] }
-
-## Async client dependencies
-# Postgres async client
-tokio-postgres = { version = "0.7.13", features = [] }
-# Async utils
-futures = "0.3.31"
-
-## Async features dependencies
-# Async connection pooling
-deadpool-postgres = { version = "0.14.1", optional = true }
+wasm-async = ["tokio-postgres/js"]

--- a/clorinde/Cargo.toml
+++ b/clorinde/Cargo.toml
@@ -44,3 +44,4 @@ tempfile = "3.19.1"
 # Config handling
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.22"
+cargo_toml = "0.22.1"

--- a/clorinde/src/codegen/cargo.rs
+++ b/clorinde/src/codegen/cargo.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashSet, fmt::Write, fs, path::Path};
+use std::{collections::HashSet, fs, path::Path};
 
+use cargo_toml::{Dependency, DependencyDetail, InheritedDependencyDetail};
 use postgres_types::{Kind, Type};
 
-use crate::config::{Config, CrateDependency, DependencyTable, UseWorkspaceDeps};
+use crate::config::{Config, DependencyTable, UseWorkspaceDeps};
 
 /// Register use of typed requiring specific dependencies
 #[derive(Debug, Clone, Default)]
@@ -41,268 +42,286 @@ impl DependencyAnalysis {
     }
 }
 
-struct CargoWriter {
-    buf: String,
-    use_workspace_deps: bool,
-    workspace_deps: HashSet<String>,
-    custom_deps: HashSet<String>,
+fn get_workspace_deps(manifest_path: &Path) -> HashSet<String> {
+    let mut deps = HashSet::new();
+    if let Ok(contents) = fs::read_to_string(manifest_path) {
+        if let Ok(manifest) = contents.parse::<toml::Value>() {
+            if let Some(workspace) = manifest
+                .get("workspace")
+                .and_then(|w| w.get("dependencies"))
+            {
+                deps.extend(
+                    workspace
+                        .as_table()
+                        .into_iter()
+                        .flat_map(|t| t.keys())
+                        .map(|s| s.to_string()),
+                );
+            }
+        }
+    }
+    deps
 }
 
-impl CargoWriter {
-    fn get_workspace_deps(manifest_path: &Path) -> HashSet<String> {
-        let mut deps = HashSet::new();
-        if let Ok(contents) = fs::read_to_string(manifest_path) {
-            if let Ok(manifest) = contents.parse::<toml::Value>() {
-                if let Some(workspace) = manifest
-                    .get("workspace")
-                    .and_then(|w| w.get("dependencies"))
-                {
-                    deps.extend(
-                        workspace
-                            .as_table()
-                            .into_iter()
-                            .flat_map(|t| t.keys())
-                            .map(|s| s.to_string()),
-                    );
-                }
-            }
-        }
-        deps
-    }
+fn to_cargo_dep(dep: &DependencyTable, use_workspace: bool) -> Dependency {
+    if use_workspace {
+        // for workspace dependencies, use Inherited variant
+        let mut inherited = InheritedDependencyDetail::default();
+        inherited.workspace = true;
 
-    fn new(config: &Config) -> Self {
-        let use_workspace_deps = match &config.use_workspace_deps {
-            UseWorkspaceDeps::Bool(enabled) => *enabled,
-            UseWorkspaceDeps::Path(_) => true,
-        };
-
-        let workspace_deps = match &config.use_workspace_deps {
-            UseWorkspaceDeps::Bool(true) => {
-                CargoWriter::get_workspace_deps(Path::new("./Cargo.toml"))
-            }
-            UseWorkspaceDeps::Bool(false) => HashSet::new(),
-            UseWorkspaceDeps::Path(path) => CargoWriter::get_workspace_deps(path),
-        };
-
-        let custom_deps = config.types.crate_info.keys().cloned().collect();
-
-        Self {
-            buf: String::new(),
-            use_workspace_deps,
-            workspace_deps,
-            custom_deps,
-        }
-    }
-
-    fn line(&mut self, line: &str) {
-        writeln!(self.buf, "{}", line).unwrap();
-    }
-
-    fn dep(&mut self, name: &str, dep: DependencyTable) {
-        if self.custom_deps.contains(name) {
-            return;
+        if let Some(features) = &dep.features {
+            inherited.features = features.clone();
         }
 
-        self.add_dep(name, dep);
-    }
-
-    fn add_dep(&mut self, name: &str, mut dep: DependencyTable) {
-        // add `workspace = true` when `use-workspace-deps` option is enabled
-        // and dependency appears in user's Cargo.toml `[workspace.dependencies]`
-        if self.use_workspace_deps && self.workspace_deps.contains(name) {
-            dep.version = None;
-            dep.workspace = Some(true);
-        } else {
-            dep.workspace = None;
+        if let Some(optional) = dep.optional {
+            inherited.optional = optional;
         }
 
-        if dep.is_simple_version() {
-            writeln!(self.buf, "{} = \"{}\"", name, dep.version.unwrap()).unwrap();
-        } else {
-            let dep_str = toml::to_string(&dep)
-                .unwrap()
-                .replace('\n', ", ")
-                .trim_end_matches(", ")
-                .to_string();
-
-            writeln!(self.buf, "{} = {{ {} }}", name, dep_str).unwrap();
-        }
-    }
-
-    fn into_string(self) -> String {
-        self.buf
+        Dependency::Inherited(inherited)
+    } else {
+        let mut detail = DependencyDetail::default();
+        detail.version = dep.version.clone();
+        detail.path = dep.path.clone();
+        detail.features = dep.features.clone().unwrap_or_default();
+        detail.optional = dep.optional.unwrap_or(false);
+        detail.default_features = dep.default_features.unwrap_or(true);
+        Dependency::Detailed(Box::new(detail))
     }
 }
 
 pub fn gen_cargo_file(dependency_analysis: &DependencyAnalysis, config: &Config) -> String {
-    let mut cargo = CargoWriter::new(config);
+    let mut manifest = config.manifest.clone();
 
-    cargo.line("# This file was generated with `clorinde`. Do not modify.");
-    cargo.line(
-        &config
-            .package
-            .to_string()
-            .expect("unable to serialize package"),
-    );
+    let (use_workspace_deps, workspace_deps) = match &config.use_workspace_deps {
+        UseWorkspaceDeps::Bool(true) => (true, get_workspace_deps(Path::new("./Cargo.toml"))),
+        UseWorkspaceDeps::Bool(false) => (false, HashSet::new()),
+        UseWorkspaceDeps::Path(path) => (true, get_workspace_deps(path)),
+    };
 
     if config.r#async {
-        let mut default_features = vec!["\"deadpool\""];
+        let mut default_features = vec!["deadpool".to_string()];
         if dependency_analysis.has_dependency() && dependency_analysis.chrono {
-            default_features.push("\"chrono\"");
+            default_features.push("chrono".to_string());
         }
 
-        let mut wasm_features = vec!["\"tokio-postgres/js\""];
-        if dependency_analysis.has_dependency() && dependency_analysis.chrono {
-            wasm_features.push("\"chrono?/wasmbind\"");
-            wasm_features.push("\"time?/wasm-bindgen\"");
-        }
+        manifest
+            .features
+            .insert("default".to_string(), default_features);
+        manifest.features.insert(
+            "deadpool".to_string(),
+            vec![
+                "dep:deadpool-postgres".to_string(),
+                "tokio-postgres/default".to_string(),
+            ],
+        );
 
-        cargo.line("[features]");
-        cargo.line(&format!("default = [{}]", default_features.join(", ")));
-        cargo.line("deadpool = [\"dep:deadpool-postgres\", \"tokio-postgres/default\"]");
-        cargo.line(&format!("wasm-async = [{}]", wasm_features.join(", ")));
+        let mut wasm_features = vec!["tokio-postgres/js".to_string()];
+        if dependency_analysis.has_dependency() && dependency_analysis.chrono {
+            wasm_features.push("chrono?/wasmbind".to_string());
+            wasm_features.push("time?/wasm-bindgen".to_string());
+        }
+        manifest
+            .features
+            .insert("wasm-async".to_string(), wasm_features);
     } else {
+        manifest.features.insert("default".to_string(), vec![]);
+
         let mut wasm_features = vec![];
         if dependency_analysis.has_dependency() && dependency_analysis.chrono {
-            wasm_features.push("\"chrono?/wasmbind\"");
+            wasm_features.push("chrono?/wasmbind".to_string());
         }
-
-        cargo.line("[features]");
-        cargo.line("default = []");
-        cargo.line(&format!("wasm-sync = [{}]", wasm_features.join(", ")));
+        manifest
+            .features
+            .insert("wasm-sync".to_string(), wasm_features);
     }
 
+    // Add chrono/time features
     if dependency_analysis.chrono {
-        cargo.line("\nchrono = [\"dep:chrono\"]");
-        cargo.line("time = [\"dep:time\"]");
+        manifest
+            .features
+            .insert("chrono".to_string(), vec!["dep:chrono".to_string()]);
+        manifest
+            .features
+            .insert("time".to_string(), vec!["dep:time".to_string()]);
     } else {
-        cargo.line("\nchrono = []");
-        cargo.line("time = []");
+        manifest.features.insert("chrono".to_string(), vec![]);
+        manifest.features.insert("time".to_string(), vec![]);
     }
 
-    cargo.line("\n[dependencies]");
-    cargo.line("## Core dependencies");
-    cargo.line("# Postgres types");
-    cargo.dep(
-        "postgres-types",
-        DependencyTable::new("0.2.9").features(vec!["derive"]),
+    // Core dependencies
+    let postgres_types_dep = DependencyTable::new("0.2.9").features(vec!["derive"]);
+    manifest.dependencies.insert(
+        "postgres-types".to_string(),
+        to_cargo_dep(
+            &postgres_types_dep,
+            use_workspace_deps && workspace_deps.contains("postgres-types"),
+        ),
     );
 
-    cargo.line("# Postgres interaction");
-    cargo.dep("postgres-protocol", DependencyTable::new("0.6.8"));
+    let postgres_protocol_dep = DependencyTable::new("0.6.8");
+    manifest.dependencies.insert(
+        "postgres-protocol".to_string(),
+        to_cargo_dep(
+            &postgres_protocol_dep,
+            use_workspace_deps && workspace_deps.contains("postgres-protocol"),
+        ),
+    );
 
     let mut client_features = Vec::new();
 
+    // Type dependencies
     if dependency_analysis.has_dependency() {
-        cargo.line("\n## Types dependencies");
         if dependency_analysis.chrono {
-            cargo.line("# TIME, DATE, TIMESTAMP or TIMESTAMPZ");
-            cargo.dep(
-                "chrono",
-                DependencyTable::new("0.4.40")
-                    .features(if config.serialize || dependency_analysis.json {
-                        vec!["serde"]
-                    } else {
-                        vec![]
-                    })
-                    .optional(),
-            );
-            cargo.dep("time", DependencyTable::new("0.3.41").optional());
-
-            client_features.push("with-chrono-0_4".to_string());
-            client_features.push("with-time-0_3".to_string());
-        }
-        if dependency_analysis.uuid {
-            cargo.line("# UUID");
-            cargo.dep(
-                "uuid",
-                DependencyTable::new("1.16.0").features(
-                    if config.serialize || dependency_analysis.json {
-                        vec!["serde"]
-                    } else {
-                        vec![]
-                    },
+            let chrono_features = if config.serialize || dependency_analysis.json {
+                vec!["serde"]
+            } else {
+                vec![]
+            };
+            let chrono_dep = DependencyTable::new("0.4.40")
+                .features(chrono_features)
+                .optional();
+            manifest.dependencies.insert(
+                "chrono".to_string(),
+                to_cargo_dep(
+                    &chrono_dep,
+                    use_workspace_deps && workspace_deps.contains("chrono"),
                 ),
             );
-            client_features.push("with-uuid-1".to_string());
+
+            let time_dep = DependencyTable::new("0.3.41").optional();
+            manifest.dependencies.insert(
+                "time".to_string(),
+                to_cargo_dep(
+                    &time_dep,
+                    use_workspace_deps && workspace_deps.contains("time"),
+                ),
+            );
+
+            client_features.push("with-chrono-0_4");
+            client_features.push("with-time-0_3");
         }
+
+        if dependency_analysis.uuid {
+            let uuid_features = if config.serialize || dependency_analysis.json {
+                vec!["serde"]
+            } else {
+                vec![]
+            };
+
+            let uuid_dep = DependencyTable::new("1.16.0").features(uuid_features);
+            manifest.dependencies.insert(
+                "uuid".to_string(),
+                to_cargo_dep(
+                    &uuid_dep,
+                    use_workspace_deps && workspace_deps.contains("uuid"),
+                ),
+            );
+            client_features.push("with-uuid-1");
+        }
+
         if dependency_analysis.mac_addr {
-            cargo.line("# MAC ADDRESS");
-            cargo.dep("eui48", DependencyTable::new("1.1.0").no_default_features());
-            client_features.push("with-eui48-1".to_string());
+            let eui48_dep = DependencyTable::new("1.1.0").no_default_features();
+            manifest.dependencies.insert(
+                "eui48".to_string(),
+                to_cargo_dep(
+                    &eui48_dep,
+                    use_workspace_deps && workspace_deps.contains("eui48"),
+                ),
+            );
+            client_features.push("with-eui48-1");
         }
+
         if dependency_analysis.decimal {
-            cargo.line("# DECIMAL");
-            cargo.dep(
-                "rust_decimal",
-                DependencyTable::new("1.37.1").features(vec!["db-postgres"]),
+            let rust_decimal_dep = DependencyTable::new("1.37.1").features(vec!["db-postgres"]);
+            manifest.dependencies.insert(
+                "rust_decimal".to_string(),
+                to_cargo_dep(
+                    &rust_decimal_dep,
+                    use_workspace_deps && workspace_deps.contains("rust_decimal"),
+                ),
             );
         }
+
         if dependency_analysis.json {
-            cargo.line("# JSON or JSONB");
-            cargo.dep(
-                "serde_json",
-                DependencyTable::new("1.0.140").features(vec!["raw_value"]),
+            let serde_json_dep = DependencyTable::new("1.0.140").features(vec!["raw_value"]);
+            manifest.dependencies.insert(
+                "serde_json".to_string(),
+                to_cargo_dep(
+                    &serde_json_dep,
+                    use_workspace_deps && workspace_deps.contains("serde_json"),
+                ),
             );
-            cargo.dep(
-                "serde",
-                DependencyTable::new("1.0.219").features(vec!["derive"]),
+
+            let serde_dep = DependencyTable::new("1.0.219").features(vec!["derive"]);
+            manifest.dependencies.insert(
+                "serde".to_string(),
+                to_cargo_dep(
+                    &serde_dep,
+                    use_workspace_deps && workspace_deps.contains("serde"),
+                ),
             );
-            client_features.push("with-serde_json-1".to_string());
+            client_features.push("with-serde_json-1");
         }
     }
 
-    // add serde if serializing but not using json type
+    // Add serde if serializing but not using json type
     if config.serialize && !dependency_analysis.json {
-        cargo.line("# JSON or JSONB");
-        cargo.dep(
-            "serde",
-            DependencyTable::new("1.0.219").features(vec!["derive"]),
+        let serde_dep = DependencyTable::new("1.0.219").features(vec!["derive"]);
+        manifest.dependencies.insert(
+            "serde".to_string(),
+            to_cargo_dep(
+                &serde_dep,
+                use_workspace_deps && workspace_deps.contains("serde"),
+            ),
         );
-        client_features.push("with-serde_json-1".to_string());
+        client_features.push("with-serde_json-1");
     }
 
-    cargo.line("\n# Postgres");
-    cargo.dep(
-        "postgres",
-        DependencyTable::new("0.19.10").features(client_features.clone()),
+    // Postgres client
+    let postgres_dep = DependencyTable::new("0.19.10")
+        .features(client_features.iter().map(|s| s.to_string()).collect());
+
+    manifest.dependencies.insert(
+        "postgres".to_string(),
+        to_cargo_dep(
+            &postgres_dep,
+            use_workspace_deps && workspace_deps.contains("postgres"),
+        ),
     );
 
+    // Async dependencies
     if config.r#async {
-        cargo.line("\n## Async client dependencies");
-        cargo.line("# Postgres async client");
-        cargo.dep(
-            "tokio-postgres",
-            DependencyTable::new("0.7.13").features(client_features),
+        let tokio_postgres_dep = DependencyTable::new("0.7.13")
+            .features(client_features.iter().map(|s| s.to_string()).collect());
+
+        manifest.dependencies.insert(
+            "tokio-postgres".to_string(),
+            to_cargo_dep(
+                &tokio_postgres_dep,
+                use_workspace_deps && workspace_deps.contains("tokio-postgres"),
+            ),
         );
 
-        cargo.line("# Async utils");
-        cargo.dep("futures", DependencyTable::new("0.3.31"));
+        let futures_dep = DependencyTable::new("0.3.31");
+        manifest.dependencies.insert(
+            "futures".to_string(),
+            to_cargo_dep(
+                &futures_dep,
+                use_workspace_deps && workspace_deps.contains("futures"),
+            ),
+        );
 
-        cargo.line("\n## Async features dependencies");
-        cargo.line("# Async connection pooling");
-        cargo.dep(
-            "deadpool-postgres",
-            DependencyTable::new("0.14.1").optional(),
+        let deadpool_dep = DependencyTable::new("0.14.1").optional();
+        manifest.dependencies.insert(
+            "deadpool-postgres".to_string(),
+            to_cargo_dep(
+                &deadpool_dep,
+                use_workspace_deps && workspace_deps.contains("deadpool-postgres"),
+            ),
         );
     }
 
-    if !config.types.crate_info.is_empty() {
-        cargo.line("\n## Custom type dependencies");
-        let mut crates: Vec<_> = config.types.crate_info.iter().collect();
-        crates.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
-
-        for (name, dep) in crates {
-            match dep {
-                CrateDependency::Simple(version) => {
-                    cargo.line(&format!("{} = \"{}\"", name, version));
-                }
-                CrateDependency::Detailed(dependency) => {
-                    cargo.add_dep(name, dependency.to_owned());
-                }
-            }
-        }
-    }
-
-    cargo.into_string()
+    let mut output = String::from("# This file was generated with `clorinde`. Do not modify.\n\n");
+    output.push_str(&toml::to_string(&manifest).expect("Failed to serialize manifest"));
+    output
 }

--- a/clorinde/src/lib.rs
+++ b/clorinde/src/lib.rs
@@ -15,12 +15,13 @@ pub mod conn;
 /// High-level interfaces to work with Clorinde's container manager.
 pub mod container;
 
-use config::Config;
-
+/// Re-export of cargo_toml for working with manifest configurations
+pub use cargo_toml;
 use std::path::Path;
 
 use postgres::Client;
 
+use config::Config;
 use parser::parse_query_module;
 use prepare_queries::prepare;
 use read_queries::read_query_modules;

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,19 +1,31 @@
 # Configuration
 Clorinde can be configured using a configuration file (`clorinde.toml` by default) in your project. This file allows you to customise generated code behaviour, specify static files, manage dependencies, and override type mappings.
 
-## Package configuration
-The `[package]` section allows you to configure any standard Cargo.toml package field in the generated crate:
+## Manifest configuration
+The `[manifest]` section allows you to configure the entire Cargo.toml for the generated crate:
 
 ```toml
-[package]
+[manifest.package]
 name = "furinapp-queries"
-version = "0.1.0"
+version = "1.0.0"
 description = "Today I wanted to eat a *quaso*."
 license = "MIT"
 edition = "2021"
+
+[manifest.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+my_custom_types = { path = "../types" }
 ```
 
-All fields specified in this section will be directly copied to the `[package]` section of the generated crate's Cargo.toml. This gives you complete control over the package metadata and configuration of the generated crate.
+This gives you complete control over the generated Cargo.toml. Clorinde will automatically merge your configuration with the required PostgreSQL dependencies based on the types found in your SQL queries.
+
+### Dependency merging
+Clorinde automatically adds dependencies based on your PostgreSQL schema:
+- Core dependencies: `postgres-types`, `postgres-protocol`, `postgres`
+- Type-specific dependencies: `chrono`, `uuid`, `serde_json`, etc. (based on column types)
+- Async dependencies: `tokio-postgres`, `futures`, `deadpool-postgres` (when async enabled)
+
+Your custom dependencies in `[manifest.dependencies]` will be preserved and merged with these auto-generated ones.
 
 ## Workspace dependencies
 The `use-workspace-deps` option allows you to integrate the generated crate with your workspace's dependency management:
@@ -32,10 +44,10 @@ When this option is set, Clorinde will:
 3. Fall back to regular dependency declarations for packages not found in the workspace
 
 ## Custom type mappings
-You can configure custom type mappings and their required dependencies using the `types` section:
+You can configure custom type mappings using the `types` section:
 
 ```toml
-[types.crates]
+[manifest.dependencies]
 # Dependencies required for custom type mappings
 ctypes = { path = "../ctypes" }
 postgres_range = { version = "0.11.1", features = ["with-chrono-0_4"] }
@@ -46,7 +58,7 @@ postgres_range = { version = "0.11.1", features = ["with-chrono-0_4"] }
 "pg_catalog.tstzrange" = "postgres_range::Range<chrono::DateTime<chrono::FixedOffset>>"
 ```
 
-The `types.crates` table specifies any dependencies needed for your custom type mappings. These will be added to the generated crate's `Cargo.toml`.
+Dependencies needed for your custom type mappings should be specified in `[manifest.dependencies]`.
 
 The `types.mapping` table allows you to map PostgreSQL types to Rust types. You can use this to either override Clorinde's default mappings or add support for PostgreSQL types that aren't supported by default, such as types from extensions.
 

--- a/examples/auto_build/auto_build_codegen/Cargo.toml
+++ b/examples/auto_build/auto_build_codegen/Cargo.toml
@@ -1,34 +1,34 @@
 # This file was generated with `clorinde`. Do not modify.
+
 [package]
 name = "auto_build_codegen"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
+[dependencies.deadpool-postgres]
+version = "0.14.1"
+optional = true
+
+[dependencies.futures]
+version = "0.3.31"
+
+[dependencies.postgres]
+version = "0.19.10"
+
+[dependencies.postgres-protocol]
+version = "0.6.8"
+
+[dependencies.postgres-types]
+version = "0.2.9"
+features = ["derive"]
+
+[dependencies.tokio-postgres]
+version = "0.7.13"
+
 [features]
-default = ["deadpool"]
-deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js"]
-
 chrono = []
+deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
+default = ["deadpool"]
 time = []
-
-[dependencies]
-## Core dependencies
-# Postgres types
-postgres-types = { version = "0.2.9", features = ["derive"] }
-# Postgres interaction
-postgres-protocol = "0.6.8"
-
-# Postgres
-postgres = { version = "0.19.10", features = [] }
-
-## Async client dependencies
-# Postgres async client
-tokio-postgres = { version = "0.7.13", features = [] }
-# Async utils
-futures = "0.3.31"
-
-## Async features dependencies
-# Async connection pooling
-deadpool-postgres = { version = "0.14.1", optional = true }
+wasm-async = ["tokio-postgres/js"]

--- a/examples/basic_async/basic_async_codegen/Cargo.toml
+++ b/examples/basic_async/basic_async_codegen/Cargo.toml
@@ -1,39 +1,44 @@
 # This file was generated with `clorinde`. Do not modify.
+
 [package]
 name = "basic_async_codegen"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
+[dependencies.chrono]
+version = "0.4.40"
+optional = true
+
+[dependencies.deadpool-postgres]
+version = "0.14.1"
+optional = true
+
+[dependencies.futures]
+version = "0.3.31"
+
+[dependencies.postgres]
+version = "0.19.10"
+features = ["with-chrono-0_4", "with-time-0_3"]
+
+[dependencies.postgres-protocol]
+version = "0.6.8"
+
+[dependencies.postgres-types]
+version = "0.2.9"
+features = ["derive"]
+
+[dependencies.time]
+version = "0.3.41"
+optional = true
+
+[dependencies.tokio-postgres]
+version = "0.7.13"
+features = ["with-chrono-0_4", "with-time-0_3"]
+
 [features]
-default = ["deadpool", "chrono"]
-deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]
-
 chrono = ["dep:chrono"]
+deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
+default = ["deadpool", "chrono"]
 time = ["dep:time"]
-
-[dependencies]
-## Core dependencies
-# Postgres types
-postgres-types = { version = "0.2.9", features = ["derive"] }
-# Postgres interaction
-postgres-protocol = "0.6.8"
-
-## Types dependencies
-# TIME, DATE, TIMESTAMP or TIMESTAMPZ
-chrono = { version = "0.4.40", optional = true, features = [] }
-time = { version = "0.3.41", optional = true }
-
-# Postgres
-postgres = { version = "0.19.10", features = ["with-chrono-0_4", "with-time-0_3"] }
-
-## Async client dependencies
-# Postgres async client
-tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-time-0_3"] }
-# Async utils
-futures = "0.3.31"
-
-## Async features dependencies
-# Async connection pooling
-deadpool-postgres = { version = "0.14.1", optional = true }
+wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]

--- a/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
+++ b/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
@@ -1,34 +1,34 @@
 # This file was generated with `clorinde`. Do not modify.
+
 [package]
 name = "basic_async_wasm_codegen"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
+[dependencies.deadpool-postgres]
+version = "0.14.1"
+optional = true
+
+[dependencies.futures]
+version = "0.3.31"
+
+[dependencies.postgres]
+version = "0.19.10"
+
+[dependencies.postgres-protocol]
+version = "0.6.8"
+
+[dependencies.postgres-types]
+version = "0.2.9"
+features = ["derive"]
+
+[dependencies.tokio-postgres]
+version = "0.7.13"
+
 [features]
-default = ["deadpool"]
-deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js"]
-
 chrono = []
+deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
+default = ["deadpool"]
 time = []
-
-[dependencies]
-## Core dependencies
-# Postgres types
-postgres-types = { version = "0.2.9", features = ["derive"] }
-# Postgres interaction
-postgres-protocol = "0.6.8"
-
-# Postgres
-postgres = { version = "0.19.10", features = [] }
-
-## Async client dependencies
-# Postgres async client
-tokio-postgres = { version = "0.7.13", features = [] }
-# Async utils
-futures = "0.3.31"
-
-## Async features dependencies
-# Async connection pooling
-deadpool-postgres = { version = "0.14.1", optional = true }
+wasm-async = ["tokio-postgres/js"]

--- a/examples/basic_sync/basic_sync_codegen/Cargo.toml
+++ b/examples/basic_sync/basic_sync_codegen/Cargo.toml
@@ -1,23 +1,23 @@
 # This file was generated with `clorinde`. Do not modify.
+
 [package]
 name = "basic_sync_codegen"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
+[dependencies.postgres]
+version = "0.19.10"
+
+[dependencies.postgres-protocol]
+version = "0.6.8"
+
+[dependencies.postgres-types]
+version = "0.2.9"
+features = ["derive"]
+
 [features]
-default = []
-wasm-sync = []
-
 chrono = []
+default = []
 time = []
-
-[dependencies]
-## Core dependencies
-# Postgres types
-postgres-types = { version = "0.2.9", features = ["derive"] }
-# Postgres interaction
-postgres-protocol = "0.6.8"
-
-# Postgres
-postgres = { version = "0.19.10", features = [] }
+wasm-sync = []

--- a/examples/custom_types/README.md
+++ b/examples/custom_types/README.md
@@ -1,12 +1,12 @@
 # Adding custom types through `clorinde.toml`
 This example shows how you can add custom types to be used. You need to create a new crate which implements the `FromSql` and `ToSql` traits from `postgres-types` for your custom types.
 
-The custom type crates are imported into the Clorinde (codegen) crate for their use in the root crate.
+The custom type crates are imported into the generated Clorinde crate through the manifest configuration.
 
-By default, if no crates are specified but custom types are used, Clorinde will look for a crate named `ctypes` at the relative path `../ctypes`. You can override this default or add additional crates as needed:
+You can specify custom type dependencies in the `[manifest.dependencies]` section:
 
 ```toml
-[types.crates]
+[manifest.dependencies]
 # Local crate with a relative path
 ctypes = { path = "../ctypes" }
 
@@ -17,7 +17,7 @@ custom_types = "1.0.0"
 types_with_features = { version = "2.0", features = ["date", "time"] }
 
 # Complete example with all options
-full_example = { 
+full_example = {
     version = "1.2.3",
     path = "../local_types",
     features = ["custom_types"],
@@ -34,4 +34,4 @@ You can specify multiple crates, and each one can use any of the standard Cargo 
 - Optional dependencies
 - Any combination of these options
 
-The configuration follows the same format as dependencies in `Cargo.toml`, making it familiar and flexible to use.
+The configuration follows the same format as dependencies in `Cargo.toml`, and these dependencies will be merged with the PostgreSQL dependencies that Clorinde automatically generates based on your SQL queries.

--- a/examples/custom_types/clorinde.toml
+++ b/examples/custom_types/clorinde.toml
@@ -8,19 +8,8 @@ container-wait = 1000
 [style]
 enum-variant-camel-case = true
 
-[package]
-name = "custom_types_codegen"
-
 [types]
 derive-traits = ["Hash"]
-
-[types.crates]
-ctypes = { path = "../ctypes" }
-postgres_range = { version = "0.11.1", features = ["with-chrono-0_4"] }
-tokio-postgres = { version = "0.7.13", features = [
-    "with-chrono-0_4",
-    "with-serde_json-1",
-] }
 
 [types.type-traits-mapping]
 sponge_bob_character = ["serde::Deserialize"]
@@ -31,3 +20,18 @@ sponge_bob_character = ["serde::Deserialize"]
     'allow(dead_code)',
 ] }
 "pg_catalog.tstzrange" = "postgres_range::Range<chrono::DateTime<chrono::FixedOffset>>"
+
+[manifest.package]
+name = "custom_types_codegen"
+
+[manifest.dependencies]
+ctypes = { path = "../ctypes" }
+postgres_range = { version = "0.11.1", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7.13", features = [
+    "with-chrono-0_4",
+    "with-serde_json-1",
+] }
+
+[manifest.lints.rust]
+dead_code = "allow"
+unused_imports = "allow"

--- a/examples/custom_types/custom_types_codegen/Cargo.toml
+++ b/examples/custom_types/custom_types_codegen/Cargo.toml
@@ -1,45 +1,59 @@
 # This file was generated with `clorinde`. Do not modify.
+
 [package]
 name = "custom_types_codegen"
 version = "0.1.0"
 edition = "2021"
-publish = false
+
+[dependencies.chrono]
+features = ["serde"]
+optional = true
+workspace = true
+
+[dependencies.ctypes]
+path = "../ctypes"
+
+[dependencies.deadpool-postgres]
+version = "0.14.1"
+optional = true
+
+[dependencies.futures]
+version = "0.3.31"
+
+[dependencies.postgres]
+version = "0.19.10"
+features = ["with-chrono-0_4", "with-time-0_3", "with-serde_json-1"]
+
+[dependencies.postgres-protocol]
+version = "0.6.8"
+
+[dependencies.postgres-types]
+version = "0.2.9"
+features = ["derive"]
+
+[dependencies.postgres_range]
+version = "0.11.1"
+features = ["with-chrono-0_4"]
+
+[dependencies.serde]
+version = "1.0.219"
+features = ["derive"]
+
+[dependencies.time]
+optional = true
+workspace = true
+
+[dependencies.tokio-postgres]
+version = "0.7.13"
+features = ["with-chrono-0_4", "with-time-0_3", "with-serde_json-1"]
 
 [features]
-default = ["deadpool", "chrono"]
+chrono = ["dep:chrono"]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
+default = ["deadpool", "chrono"]
+time = ["dep:time"]
 wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]
 
-chrono = ["dep:chrono"]
-time = ["dep:time"]
-
-[dependencies]
-## Core dependencies
-# Postgres types
-postgres-types = { version = "0.2.9", features = ["derive"] }
-# Postgres interaction
-postgres-protocol = "0.6.8"
-
-## Types dependencies
-# TIME, DATE, TIMESTAMP or TIMESTAMPZ
-chrono = { workspace = true, optional = true, features = ["serde"] }
-time = { workspace = true, optional = true }
-# JSON or JSONB
-serde = { version = "1.0.219", features = ["derive"] }
-
-# Postgres
-postgres = { version = "0.19.10", features = ["with-chrono-0_4", "with-time-0_3", "with-serde_json-1"] }
-
-## Async client dependencies
-# Postgres async client
-# Async utils
-futures = "0.3.31"
-
-## Async features dependencies
-# Async connection pooling
-deadpool-postgres = { version = "0.14.1", optional = true }
-
-## Custom type dependencies
-ctypes = { path = "../ctypes" }
-postgres_range = { version = "0.11.1", features = ["with-chrono-0_4"] }
-tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-serde_json-1"] }
+[lints.rust]
+dead_code = "allow"
+unused_imports = "allow"

--- a/tests/codegen/codegen/Cargo.toml
+++ b/tests/codegen/codegen/Cargo.toml
@@ -1,48 +1,65 @@
 # This file was generated with `clorinde`. Do not modify.
+
 [package]
 name = "codegen"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
+[dependencies.chrono]
+version = "0.4.40"
+features = ["serde"]
+optional = true
+
+[dependencies.deadpool-postgres]
+version = "0.14.1"
+optional = true
+
+[dependencies.eui48]
+version = "1.1.0"
+default-features = false
+
+[dependencies.futures]
+version = "0.3.31"
+
+[dependencies.postgres]
+version = "0.19.10"
+features = ["with-chrono-0_4", "with-time-0_3", "with-uuid-1", "with-eui48-1", "with-serde_json-1"]
+
+[dependencies.postgres-protocol]
+version = "0.6.8"
+
+[dependencies.postgres-types]
+version = "0.2.9"
+features = ["derive"]
+
+[dependencies.rust_decimal]
+version = "1.37.1"
+features = ["db-postgres"]
+
+[dependencies.serde]
+version = "1.0.219"
+features = ["derive"]
+
+[dependencies.serde_json]
+version = "1.0.140"
+features = ["raw_value"]
+
+[dependencies.time]
+version = "0.3.41"
+optional = true
+
+[dependencies.tokio-postgres]
+version = "0.7.13"
+features = ["with-chrono-0_4", "with-time-0_3", "with-uuid-1", "with-eui48-1", "with-serde_json-1"]
+
+[dependencies.uuid]
+version = "1.16.0"
+features = ["serde"]
+
 [features]
-default = ["deadpool", "chrono"]
-deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]
-
 chrono = ["dep:chrono"]
+deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
+default = ["deadpool", "chrono"]
 time = ["dep:time"]
-
-[dependencies]
-## Core dependencies
-# Postgres types
-postgres-types = { version = "0.2.9", features = ["derive"] }
-# Postgres interaction
-postgres-protocol = "0.6.8"
-
-## Types dependencies
-# TIME, DATE, TIMESTAMP or TIMESTAMPZ
-chrono = { version = "0.4.40", optional = true, features = ["serde"] }
-time = { version = "0.3.41", optional = true }
-# UUID
-uuid = { version = "1.16.0", features = ["serde"] }
-# MAC ADDRESS
-eui48 = { version = "1.1.0", default-features = false }
-# DECIMAL
-rust_decimal = { version = "1.37.1", features = ["db-postgres"] }
-# JSON or JSONB
-serde_json = { version = "1.0.140", features = ["raw_value"] }
-serde = { version = "1.0.219", features = ["derive"] }
-
-# Postgres
-postgres = { version = "0.19.10", features = ["with-chrono-0_4", "with-time-0_3", "with-uuid-1", "with-eui48-1", "with-serde_json-1"] }
-
-## Async client dependencies
-# Postgres async client
-tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-time-0_3", "with-uuid-1", "with-eui48-1", "with-serde_json-1"] }
-# Async utils
-futures = "0.3.31"
-
-## Async features dependencies
-# Async connection pooling
-deadpool-postgres = { version = "0.14.1", optional = true }
+wasm-async = ["tokio-postgres/js", "chrono?/wasmbind", "time?/wasm-bindgen"]

--- a/tests/integration/src/fixtures.rs
+++ b/tests/integration/src/fixtures.rs
@@ -74,7 +74,9 @@ impl From<&CodegenTest> for Config {
             true => Config::from_file(Path::new("./clorinde.toml")).unwrap(),
             false => {
                 let mut cfg = Config::default();
-                cfg.package.name = codegen_test.destination.to_str().unwrap().to_string();
+                if let Some(package) = &mut cfg.manifest.package {
+                    package.name = codegen_test.destination.to_str().unwrap().to_string();
+                }
                 cfg
             }
         };


### PR DESCRIPTION
Replaces the limited package configuration with full `cargo_toml::Manifest` support, giving users complete control over the generated `Cargo.toml` while maintaining automatic dependency management. Resolves #108.

### Breaking Changes:
- Config field change: `package: Package` -> `manifest: cargo_toml::Manifest`
- TOML configuration: `[package]` -> `[manifest.package]` and `[manifest.dependencies]`
- Removed: `[types.crates]` field (use `[manifest.dependencies]` instead)

### Migration:

Before:
```toml
[package]
name = "my-crate"
version = "1.0.0"

[types.crates]
my_types = { path = "../types" }
```

After:
```toml
[manifest.package]
name = "my-crate"
version = "1.0.0"

[manifest.dependencies]
my_types = { path = "../types" }
```