### PR TITLE
Fix WASM compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ name = "auto_build_codegen"
 version = "0.0.0"
 dependencies = [
  "deadpool-postgres",
+ "fallible-iterator",
  "futures",
  "postgres",
  "postgres-protocol",
@@ -232,6 +233,7 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "deadpool-postgres",
+ "fallible-iterator",
  "futures",
  "postgres",
  "postgres-protocol",
@@ -244,6 +246,7 @@ name = "basic_async_wasm_codegen"
 version = "0.0.0"
 dependencies = [
  "deadpool-postgres",
+ "fallible-iterator",
  "futures",
  "postgres",
  "postgres-protocol",
@@ -262,6 +265,7 @@ dependencies = [
 name = "basic_sync_codegen"
 version = "0.0.0"
 dependencies = [
+ "fallible-iterator",
  "postgres",
  "postgres-protocol",
  "postgres-types",
@@ -530,6 +534,7 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "eui48",
+ "fallible-iterator",
  "futures",
  "postgres",
  "postgres-protocol",
@@ -701,6 +706,7 @@ dependencies = [
  "chrono",
  "db_types",
  "deadpool-postgres",
+ "fallible-iterator",
  "futures",
  "postgres",
  "postgres-protocol",
@@ -1102,6 +1108,7 @@ name = "generated"
 version = "0.0.0"
 dependencies = [
  "deadpool-postgres",
+ "fallible-iterator",
  "futures",
  "postgres",
  "postgres-protocol",

--- a/benches/generated/Cargo.toml
+++ b/benches/generated/Cargo.toml
@@ -29,6 +29,7 @@ features = ["derive"]
 
 [dependencies.tokio-postgres]
 version = "0.7.13"
+default-features = false
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]

--- a/benches/generated/Cargo.toml
+++ b/benches/generated/Cargo.toml
@@ -10,11 +10,15 @@ publish = false
 version = "0.14.1"
 optional = true
 
+[dependencies.fallible-iterator]
+version = "0.2.0"
+
 [dependencies.futures]
 version = "0.3.31"
 
 [dependencies.postgres]
 version = "0.19.10"
+optional = true
 
 [dependencies.postgres-protocol]
 version = "0.6.8"
@@ -28,5 +32,5 @@ version = "0.7.13"
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-default = ["deadpool"]
+default = ["dep:postgres", "deadpool"]
 wasm-async = ["tokio-postgres/js"]

--- a/benches/generated/src/array_iterator.rs
+++ b/benches/generated/src/array_iterator.rs
@@ -1,7 +1,7 @@
 // This file was generated with `clorinde`. Do not modify.
 
 use super::utils::escape_domain;
-use postgres::fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{ArrayValues, array_from_sql};
 use postgres_types::{FromSql, Kind, Type};
 use std::fmt::Debug;

--- a/examples/auto_build/auto_build_codegen/Cargo.toml
+++ b/examples/auto_build/auto_build_codegen/Cargo.toml
@@ -29,6 +29,7 @@ features = ["derive"]
 
 [dependencies.tokio-postgres]
 version = "0.7.13"
+default-features = false
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]

--- a/examples/auto_build/auto_build_codegen/Cargo.toml
+++ b/examples/auto_build/auto_build_codegen/Cargo.toml
@@ -10,11 +10,15 @@ publish = false
 version = "0.14.1"
 optional = true
 
+[dependencies.fallible-iterator]
+version = "0.2.0"
+
 [dependencies.futures]
 version = "0.3.31"
 
 [dependencies.postgres]
 version = "0.19.10"
+optional = true
 
 [dependencies.postgres-protocol]
 version = "0.6.8"
@@ -28,5 +32,5 @@ version = "0.7.13"
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-default = ["deadpool"]
+default = ["dep:postgres", "deadpool"]
 wasm-async = ["tokio-postgres/js"]

--- a/examples/auto_build/auto_build_codegen/src/array_iterator.rs
+++ b/examples/auto_build/auto_build_codegen/src/array_iterator.rs
@@ -1,7 +1,7 @@
 // This file was generated with `clorinde`. Do not modify.
 
 use super::utils::escape_domain;
-use postgres::fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{ArrayValues, array_from_sql};
 use postgres_types::{FromSql, Kind, Type};
 use std::fmt::Debug;

--- a/examples/basic_async/basic_async_codegen/Cargo.toml
+++ b/examples/basic_async/basic_async_codegen/Cargo.toml
@@ -35,6 +35,7 @@ features = ["derive"]
 [dependencies.tokio-postgres]
 version = "0.7.13"
 features = ["with-chrono-0_4"]
+default-features = false
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]

--- a/examples/basic_async/basic_async_codegen/Cargo.toml
+++ b/examples/basic_async/basic_async_codegen/Cargo.toml
@@ -14,12 +14,16 @@ optional = true
 version = "0.14.1"
 optional = true
 
+[dependencies.fallible-iterator]
+version = "0.2.0"
+
 [dependencies.futures]
 version = "0.3.31"
 
 [dependencies.postgres]
 version = "0.19.10"
 features = ["with-chrono-0_4"]
+optional = true
 
 [dependencies.postgres-protocol]
 version = "0.6.8"
@@ -34,5 +38,5 @@ features = ["with-chrono-0_4"]
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-default = ["deadpool", "chrono"]
+default = ["dep:postgres", "deadpool", "chrono"]
 wasm-async = ["tokio-postgres/js", "chrono?/wasmbind"]

--- a/examples/basic_async/basic_async_codegen/src/array_iterator.rs
+++ b/examples/basic_async/basic_async_codegen/src/array_iterator.rs
@@ -1,7 +1,7 @@
 // This file was generated with `clorinde`. Do not modify.
 
 use super::utils::escape_domain;
-use postgres::fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{ArrayValues, array_from_sql};
 use postgres_types::{FromSql, Kind, Type};
 use std::fmt::Debug;

--- a/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
+++ b/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
@@ -29,6 +29,7 @@ features = ["derive"]
 
 [dependencies.tokio-postgres]
 version = "0.7.13"
+default-features = false
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]

--- a/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
+++ b/examples/basic_async_wasm/basic_async_wasm_codegen/Cargo.toml
@@ -10,11 +10,15 @@ publish = false
 version = "0.14.1"
 optional = true
 
+[dependencies.fallible-iterator]
+version = "0.2.0"
+
 [dependencies.futures]
 version = "0.3.31"
 
 [dependencies.postgres]
 version = "0.19.10"
+optional = true
 
 [dependencies.postgres-protocol]
 version = "0.6.8"
@@ -28,5 +32,5 @@ version = "0.7.13"
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-default = ["deadpool"]
+default = ["dep:postgres", "deadpool"]
 wasm-async = ["tokio-postgres/js"]

--- a/examples/basic_async_wasm/basic_async_wasm_codegen/src/array_iterator.rs
+++ b/examples/basic_async_wasm/basic_async_wasm_codegen/src/array_iterator.rs
@@ -1,7 +1,7 @@
 // This file was generated with `clorinde`. Do not modify.
 
 use super::utils::escape_domain;
-use postgres::fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{ArrayValues, array_from_sql};
 use postgres_types::{FromSql, Kind, Type};
 use std::fmt::Debug;

--- a/examples/basic_sync/basic_sync_codegen/Cargo.toml
+++ b/examples/basic_sync/basic_sync_codegen/Cargo.toml
@@ -6,8 +6,12 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[dependencies.fallible-iterator]
+version = "0.2.0"
+
 [dependencies.postgres]
 version = "0.19.10"
+optional = true
 
 [dependencies.postgres-protocol]
 version = "0.6.8"
@@ -17,5 +21,5 @@ version = "0.2.9"
 features = ["derive"]
 
 [features]
-default = []
+default = ["dep:postgres"]
 wasm-sync = []

--- a/examples/basic_sync/basic_sync_codegen/src/array_iterator.rs
+++ b/examples/basic_sync/basic_sync_codegen/src/array_iterator.rs
@@ -1,7 +1,7 @@
 // This file was generated with `clorinde`. Do not modify.
 
 use super::utils::escape_domain;
-use postgres::fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{ArrayValues, array_from_sql};
 use postgres_types::{FromSql, Kind, Type};
 use std::fmt::Debug;

--- a/examples/custom_types/db/custom_types_codegen/Cargo.toml
+++ b/examples/custom_types/db/custom_types_codegen/Cargo.toml
@@ -18,6 +18,9 @@ path = "../db_types"
 version = "0.14.1"
 optional = true
 
+[dependencies.fallible-iterator]
+version = "0.2.0"
+
 [dependencies.futures]
 version = "0.3.31"
 

--- a/examples/custom_types/db/custom_types_codegen/src/array_iterator.rs
+++ b/examples/custom_types/db/custom_types_codegen/src/array_iterator.rs
@@ -1,7 +1,7 @@
 // This file was generated with `clorinde`. Do not modify.
 
 use super::utils::escape_domain;
-use postgres::fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{ArrayValues, array_from_sql};
 use postgres_types::{FromSql, Kind, Type};
 use std::fmt::Debug;

--- a/src/codegen/cargo.rs
+++ b/src/codegen/cargo.rs
@@ -121,7 +121,7 @@ struct DependencyContext<'a> {
     workspace_deps: &'a HashSet<String>,
 }
 
-impl<'a> DependencyContext<'a> {
+impl DependencyContext<'_> {
     fn to_cargo_dep(&self, dep: &DependencyDetail, use_workspace: bool) -> Dependency {
         if use_workspace {
             // for workspace dependencies, use Inherited variant
@@ -363,6 +363,7 @@ pub fn gen_cargo_file(dependency_analysis: &DependencyAnalysis, config: &Config)
             "tokio-postgres",
             &DependencyBuilder::new(versions::TOKIO_POSTGRES)
                 .features(client_features.clone())
+                .no_default_features()
                 .into_detail(),
         );
 

--- a/src/codegen/client.rs
+++ b/src/codegen/client.rs
@@ -245,7 +245,7 @@ pub fn core_domain() -> proc_macro2::TokenStream {
 
 pub fn core_array() -> proc_macro2::TokenStream {
     quote! {
-        use postgres::fallible_iterator::FallibleIterator;
+        use fallible_iterator::FallibleIterator;
         use postgres_protocol::types::{array_from_sql, ArrayValues};
         use postgres_types::{FromSql, Kind, Type};
         use std::fmt::Debug;

--- a/tests/codegen/codegen/Cargo.toml
+++ b/tests/codegen/codegen/Cargo.toml
@@ -52,6 +52,7 @@ features = ["raw_value"]
 [dependencies.tokio-postgres]
 version = "0.7.13"
 features = ["with-chrono-0_4", "with-uuid-1", "with-eui48-1", "with-serde_json-1"]
+default-features = false
 
 [dependencies.uuid]
 version = "1.17.0"

--- a/tests/codegen/codegen/Cargo.toml
+++ b/tests/codegen/codegen/Cargo.toml
@@ -19,12 +19,16 @@ optional = true
 version = "1.1.0"
 default-features = false
 
+[dependencies.fallible-iterator]
+version = "0.2.0"
+
 [dependencies.futures]
 version = "0.3.31"
 
 [dependencies.postgres]
 version = "0.19.10"
 features = ["with-chrono-0_4", "with-uuid-1", "with-eui48-1", "with-serde_json-1"]
+optional = true
 
 [dependencies.postgres-protocol]
 version = "0.6.8"
@@ -55,5 +59,5 @@ features = ["serde"]
 
 [features]
 deadpool = ["dep:deadpool-postgres", "tokio-postgres/default"]
-default = ["deadpool", "chrono"]
+default = ["dep:postgres", "deadpool", "chrono"]
 wasm-async = ["tokio-postgres/js", "chrono?/wasmbind"]

--- a/tests/codegen/codegen/src/array_iterator.rs
+++ b/tests/codegen/codegen/src/array_iterator.rs
@@ -1,7 +1,7 @@
 // This file was generated with `clorinde`. Do not modify.
 
 use super::utils::escape_domain;
-use postgres::fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{ArrayValues, array_from_sql};
 use postgres_types::{FromSql, Kind, Type};
 use std::fmt::Debug;


### PR DESCRIPTION
postgres is unconditionally added as a non-optional dependency, which prevents generated crates from being compiled in wasm with --features wasm-async.

Make it an optional dependency and include fallible_iterator as a non-optional dependency.

Fixes #135