### PR TITLE
fix: specify concrete type for cargo_toml::Package

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -320,7 +320,7 @@ impl ConfigBuilder {
     }
 
     /// Set package metadata for the generated `Cargo.toml`
-    pub fn package(mut self, package: cargo_toml::Package) -> Self {
+    pub fn package(mut self, package: cargo_toml::Package<toml::Value>) -> Self {
         self.config.manifest.package = Some(package);
         self
     }


### PR DESCRIPTION
<!-- Add your description of the PR here -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
For some reason #159 fails with `error[E0308]: mismatched types` at compile time. I'm not sure why this error occurs when updating toml from 0.8 to 0.9, as I had compared [`toml::Value`](https://docs.rs/toml/latest/toml/enum.Value.html) across the two versions and they are the same. But this fixes it.

### How has this been tested?
```
cargo run --package test_integration -- --apply-codegen --podman
```
I tested it both with toml 0.8 and 0.9 (applying the changes in #159). Everything passed in both versions.

### The following has been done
<!-- Mark each item as done by replace the space in '[ ]' with an 'x', e.g. '[x]' -->

- [x] PR title is prefixed with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] The message body above clearly illustrates what problems it solves
- [x] If this PR has changed code within `src`, codegen for the repo has been run with `cargo run --package test_integration -- --apply-codegen`

### Tests and linting

- [x] Formatting has been run with `cargo fmt`
- [x] Tests and lints have been run with `cargo test --all` and `cargo clippy`
