### PR TITLE
docs: fix typo in tests/integration/README.md

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -4,7 +4,7 @@ This acts like a testing harness. It manages the database required for testing, 
 
 Our integration testing not only checks that Clorinde is able to generate the code, but it also tests that the right error messages are reported in case of user errors. It also runs the generated code to ensure its correctness.
 
-The test cases are auto-described using TOML fixtures. These files are deserialized when the integration tests are run and describe what should be generated, where it shoulld be generated, etc.
+The test cases are auto-described using TOML fixtures. These files are deserialized when the integration tests are run and describe what should be generated, where it should be generated, etc.
 
 # How to use
 


### PR DESCRIPTION
<!-- Add your description of the PR here -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
"should" was misspelt as "shoulld"

### How has this been tested?
<!-- Please describe in detail how you tested your changes. N/A if it is a docs change -->
N/A

### The following has been done
<!-- Mark each item as done by replace the space in '[ ]' with an 'x', e.g. '[x]' -->

- [x] PR title is prefixed with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] The message body above clearly illustrates what problems it solves
- [x] If this PR has changed code within `src`, codegen for the repo has been run with `cargo run --package test_integration -- --apply-codegen`

### Tests and linting

- [x] Formatting has been run with `cargo fmt`
- [x] Tests and lints have been run with `cargo test --all` and `cargo clippy`
