### PR TITLE
fix: use default type arg for cargo_toml::Manifest

### DIFF
--- a/src/codegen/cargo.rs
+++ b/src/codegen/cargo.rs
@@ -120,7 +120,7 @@ impl DependencyBuilder {
 }
 
 struct DependencyContext<'a> {
-    manifest: &'a mut cargo_toml::Manifest<toml::Value>,
+    manifest: &'a mut cargo_toml::Manifest,
     use_workspace: bool,
     workspace_deps: &'a HashSet<String>,
 }
@@ -156,7 +156,7 @@ impl DependencyContext<'_> {
 fn get_workspace_deps(manifest_path: &Path) -> HashSet<String> {
     let mut deps = HashSet::new();
     if let Ok(contents) = fs::read_to_string(manifest_path) {
-        if let Ok(manifest) = contents.parse::<toml::Value>() {
+        if let Ok(manifest) = contents.parse::<cargo_toml::Value>() {
             if let Some(workspace) = manifest
                 .get("workspace")
                 .and_then(|w| w.get("dependencies"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ pub struct Config {
     /// Custom type settings
     pub types: Types,
     /// The Cargo.toml manifest configuration
-    pub manifest: cargo_toml::Manifest<toml::Value>,
+    pub manifest: cargo_toml::Manifest,
 }
 
 impl Config {
@@ -188,7 +188,7 @@ impl TypeMapping {
 }
 
 #[allow(deprecated)]
-fn default_manifest() -> cargo_toml::Manifest<toml::Value> {
+fn default_manifest() -> cargo_toml::Manifest {
     let mut package = cargo_toml::Package::new("clorinde", "0.0.0");
     package.edition = cargo_toml::Inheritable::Set(cargo_toml::Edition::E2021);
     package.publish = cargo_toml::Inheritable::Set(cargo_toml::Publish::Flag(false));
@@ -314,13 +314,13 @@ impl ConfigBuilder {
     }
 
     /// Set the entire Cargo.toml manifest
-    pub fn manifest(mut self, manifest: cargo_toml::Manifest<toml::Value>) -> Self {
+    pub fn manifest(mut self, manifest: cargo_toml::Manifest) -> Self {
         self.config.manifest = manifest;
         self
     }
 
     /// Set package metadata for the generated `Cargo.toml`
-    pub fn package(mut self, package: cargo_toml::Package<toml::Value>) -> Self {
+    pub fn package(mut self, package: cargo_toml::Package) -> Self {
         self.config.manifest.package = Some(package);
         self
     }


### PR DESCRIPTION
<!-- Add your description of the PR here -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Sorry for another PR right after #165 was merged, but I thought more on how I fixed the error in #165 (specifying `toml::Value` to not use the default `cargo_toml::Value`) and figured I should have done it the other way around: change the `toml::Value`s to the default `cargo_toml::Value`. The two types are the exact same (behind the type aliases):
- https://docs.rs/cargo_toml/latest/cargo_toml/enum.Value.html
- https://docs.rs/toml/latest/toml/enum.Value.html

This offers two benefits:
1. Clorinde users who want to call [`ConfigBuilder.manifest`](https://docs.rs/clorinde/latest/clorinde/config/struct.ConfigBuilder.html#method.manifest) will only need `cargo_toml` to construct the Manifest. Currently they also need `toml` because of the `toml::Value` in Manifest. (would this be considered a breaking change?)
3. The [doc of `cargo_toml::Manifest`](https://docs.rs/cargo_toml/0.22.1/cargo_toml/struct.Manifest.html) says 
> The Metadata is a generic type for [package.metadata] table. You can replace it with your own struct type if you use the metadata and don’t want to use the catch-all Value type.

but we don't really need our own struct type. We are just replacing their catch-all Value type with another catch-all Value type. It feels unnecessary.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. N/A if it is a docs change -->
`cargo run --package test_integration -- --apply-codegen --podman`

### The following has been done
<!-- Mark each item as done by replace the space in '[ ]' with an 'x', e.g. '[x]' -->

- [x] PR title is prefixed with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] The message body above clearly illustrates what problems it solves
- [x] If this PR has changed code within `src`, codegen for the repo has been run with `cargo run --package test_integration -- --apply-codegen`

### Tests and linting

- [x] Formatting has been run with `cargo fmt`
- [x] Tests and lints have been run with `cargo test --all` and `cargo clippy`
