### PR TITLE
feat!: add custom attrs for borrowed structs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Run rustfmt
-        run: cargo +nightly fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   # Release unpublished packages.
   release-plz-release:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/src/codegen/queries.rs
+++ b/src/codegen/queries.rs
@@ -61,6 +61,7 @@ fn gen_row_structs(row: &PreparedItem, ctx: &GenCtx, config: &Config) -> proc_ma
         traits,
         is_copy,
         attributes,
+        attributes_borrowed,
         ..
     } = row;
 
@@ -129,6 +130,13 @@ fn gen_row_structs(row: &PreparedItem, ctx: &GenCtx, config: &Config) -> proc_ma
     };
 
     let borrowed_impl = if !is_copy {
+        let custom_attrs_borrowed = attributes_borrowed
+            .iter()
+            .map(|attr| {
+                syn::parse_str::<proc_macro2::TokenStream>(attr).unwrap_or_else(|_| quote!())
+            })
+            .collect::<Vec<_>>();
+
         let borrowed_name = format_ident!("{}Borrowed", name.to_string());
 
         let borrowed_fields_ty: Vec<_> = fields
@@ -165,7 +173,7 @@ fn gen_row_structs(row: &PreparedItem, ctx: &GenCtx, config: &Config) -> proc_ma
             .collect::<Vec<_>>();
 
         quote! {
-            #(#[#custom_attrs])*
+            #(#[#custom_attrs_borrowed])*
             pub struct #borrowed_name<'a> {
                 #(#borrowed_fields_with_attrs,)*
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -651,6 +651,20 @@ pub(crate) struct QueryDataStruct {
     pub idents: Option<Vec<NullableIdent>>,
 }
 
+/// Return type for name_and_fields method containing:
+/// - nullable_fields: `&'a [NullableIdent]`
+/// - traits: `Vec<String>`
+/// - name: `Span<String>`
+/// - attributes: `Vec<String>`
+/// - attributes_borrowed: `Vec<String>`
+type StructInfo<'a> = (
+    &'a [NullableIdent],
+    Vec<String>,
+    Span<String>,
+    Vec<String>,
+    Vec<String>,
+);
+
 impl QueryDataStruct {
     pub fn is_implicit(&self) -> bool {
         self.name.is_none()
@@ -669,13 +683,7 @@ impl QueryDataStruct {
         registered_structs: &'a [TypeAnnotation],
         query_name: &Span<String>,
         name_suffix: Option<&str>,
-    ) -> (
-        &'a [NullableIdent],
-        Vec<String>,
-        Span<String>,
-        Vec<String>,
-        Vec<String>,
-    ) {
+    ) -> StructInfo<'a> {
         if let Some(named) = &self.name {
             let registered = registered_structs.iter().find(|it| it.name == *named);
             (

--- a/src/prepare_queries.rs
+++ b/src/prepare_queries.rs
@@ -199,6 +199,7 @@ pub(crate) struct Preparation {
 
 #[allow(clippy::result_large_err)]
 impl PreparedModule {
+    #[allow(clippy::too_many_arguments)]
     fn add(
         info: &ModuleInfo,
         map: &mut IndexMap<Span<String>, PreparedItem>,

--- a/src/prepare_queries.rs
+++ b/src/prepare_queries.rs
@@ -129,6 +129,7 @@ pub(crate) struct PreparedItem {
     pub(crate) is_named: bool,
     pub(crate) is_ref: bool,
     pub(crate) attributes: Vec<String>,
+    pub(crate) attributes_borrowed: Vec<String>,
 }
 
 impl PreparedItem {
@@ -138,6 +139,7 @@ impl PreparedItem {
         traits: Vec<String>,
         is_implicit: bool,
         attributes: Vec<String>,
+        attributes_borrowed: Vec<String>,
     ) -> Self {
         Self {
             name,
@@ -147,6 +149,7 @@ impl PreparedItem {
             fields,
             traits,
             attributes,
+            attributes_borrowed,
         }
     }
 
@@ -204,6 +207,7 @@ impl PreparedModule {
         traits: Vec<String>,
         is_implicit: bool,
         attributes: Vec<String>,
+        attributes_borrowed: Vec<String>,
     ) -> Result<(usize, Vec<usize>), Error> {
         assert!(!fields.is_empty());
         match map.entry(name.clone()) {
@@ -230,8 +234,18 @@ impl PreparedModule {
                     traits.clone(),
                     is_implicit,
                     attributes.clone(),
+                    attributes_borrowed.clone(),
                 ));
-                Self::add(info, map, name, fields, traits, is_implicit, attributes)
+                Self::add(
+                    info,
+                    map,
+                    name,
+                    fields,
+                    traits,
+                    is_implicit,
+                    attributes,
+                    attributes_borrowed,
+                )
             }
         }
     }
@@ -244,6 +258,7 @@ impl PreparedModule {
         traits: Vec<String>,
         is_implicit: bool,
         attributes: Vec<String>,
+        attributes_borrowed: Vec<String>,
     ) -> Result<(usize, Vec<usize>), Error> {
         let nom = if fields.len() == 1 && is_implicit {
             name.map(|_| fields[0].unwrapped_name())
@@ -258,6 +273,7 @@ impl PreparedModule {
             traits,
             is_implicit,
             attributes,
+            attributes_borrowed,
         )
     }
 
@@ -275,6 +291,7 @@ impl PreparedModule {
             fields,
             vec![],
             is_implicit,
+            vec![],
             vec![],
         )
     }
@@ -541,10 +558,10 @@ fn prepare_query(
         .as_ref()
         .map_err(|e| Error::new_db_err(e, module_info, &sql_span, &name))?;
 
-    let (nullable_params_fields, _, params_name, _) =
+    let (nullable_params_fields, _, params_name, _, _) =
         param.name_and_fields(types, &name, Some("Params"));
 
-    let (nullable_row_fields, traits, row_name, row_attributes) =
+    let (nullable_row_fields, traits, row_name, row_attributes, row_attributes_borrowed) =
         row.name_and_fields(types, &name, None);
 
     let params_fields = {
@@ -659,6 +676,7 @@ fn prepare_query(
             traits,
             row.is_implicit(),
             row_attributes,
+            row_attributes_borrowed,
         )?)
     };
 

--- a/tests/codegen/codegen/src/queries/attributes.rs
+++ b/tests/codegen/codegen/src/queries/attributes.rs
@@ -29,7 +29,6 @@ pub struct BookAuthor2 {
     pub name: Option<String>,
     pub bio: String,
 }
-#[allow(deprecated)]
 pub struct BookAuthor2Borrowed<'a> {
     pub id: i32,
     pub name: Option<&'a str>,

--- a/tests/codegen/queries/attributes.sql
+++ b/tests/codegen/queries/attributes.sql
@@ -1,5 +1,6 @@
 --: BookAuthor(id, name?, bio) : serde::Serialize, serde::Deserialize
 --# cfg_attr(feature = "graphql", derive(async_graphql::SimpleObject))
+--& cfg_attr(feature = "graphql", derive(async_graphql::SimpleObject))
 --: BookAuthor2(id, name?, bio) : serde::Serialize, serde::Deserialize
 --# allow(deprecated)
 


### PR DESCRIPTION
<!-- Add your description of the PR here -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Fixes #176

Add support for `--&` syntax to specify custom attributes exclusively for borrowed struct variants. This allows separate attribute configuration for owned and borrowed structs.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. N/A if it is a docs change -->
Updated `attributes.sql` in codegen test.

### The following has been done
<!-- Mark each item as done by replace the space in '[ ]' with an 'x', e.g. '[x]' -->

- [x] PR title is prefixed with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] The message body above clearly illustrates what problems it solves
- [x] If this PR has changed code within `src`, codegen for the repo has been run with `cargo run --package test_integration -- --apply-codegen`

### Tests and linting

- [x] Formatting has been run with `cargo fmt`
- [x] Tests and lints have been run with `cargo test --all` and `cargo clippy`
