### PR TITLE
docs: smol fix on configuration.md

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -105,7 +105,7 @@ For more granular control in addition to traits in type annotations, you can spe
 # Applied to all generated structs and postgres types
 derive-traits = ["Default"]
 
-[types.derive-traits-mapping]
+[types.type-traits-mapping]
 # Applied to specfic custom postgres types (eg. enums, domains, composites)
 fontaine_region = ["serde::Deserialize"]
 ```


### PR DESCRIPTION
Current docs was using the nested table header 
[types.derive-traits-mapping] 

but it appears the correct form is
[types.type-traits-mapping]

Just fixing to avoid a papercut for a newcomer!


- [X] PR title is prefixed with `feat:`, `fix:`, `chore:`, or `docs:`
- [X] The message body above clearly illustrates what problems it solves