### PR TITLE
fix: Parsing of utf8 quoted identifiers

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -899,7 +899,10 @@ pub(crate) mod error {
 
 #[cfg(test)]
 mod tests {
-    use super::Query;
+    use std::sync::Arc;
+
+    use super::{parse_query_module, Query};
+    use crate::read_queries::ModuleInfo;
 
     #[test]
     fn find_statement_end_simple() {
@@ -957,6 +960,30 @@ mod tests {
         assert_eq!(
             Query::find_statement_end("SELECT 'it''s ; here';"),
             Some(21)
+        );
+    }
+
+    fn module_from(sql: &str) -> ModuleInfo {
+        ModuleInfo {
+            path: "test.sql".into(),
+            name: "test".to_string(),
+            full_module_path: "test".to_string(),
+            content: Arc::new(sql.to_string()),
+        }
+    }
+
+    #[test]
+    fn parse_query_bind_param_after_utf8_quoted_identifier() {
+        let sql = "--! q\nSELECT \"à\" FROM t WHERE \"à\" = :v;";
+        let module = parse_query_module(module_from(sql))
+            .expect("query with UTF-8 quoted identifier should parse successfully");
+        assert_eq!(module.queries.len(), 1);
+        let query = &module.queries[0];
+        assert_eq!(query.bind_params.len(), 1);
+        assert_eq!(query.bind_params[0].value, "v");
+        assert_eq!(
+            query.sql_str,
+            "SELECT \"à\" FROM t WHERE \"à\" = $1"
         );
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -904,7 +904,7 @@ pub(crate) mod error {
 mod tests {
     use std::sync::Arc;
 
-    use super::{parse_query_module, Query};
+    use super::{Query, parse_query_module};
     use crate::read_queries::ModuleInfo;
 
     #[test]
@@ -984,9 +984,6 @@ mod tests {
         let query = &module.queries[0];
         assert_eq!(query.bind_params.len(), 1);
         assert_eq!(query.bind_params[0].value, "v");
-        assert_eq!(
-            query.sql_str,
-            "SELECT \"à\" FROM t WHERE \"à\" = $1"
-        );
+        assert_eq!(query.sql_str, "SELECT \"à\" FROM t WHERE \"à\" = $1");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -563,9 +563,12 @@ impl Query {
 
                     if param_end > param_start {
                         let param: String = s.chars[param_start..param_end].iter().collect();
+                        let byte_start: usize =
+                            s.chars[..param_start].iter().map(|c| c.len_utf8()).sum();
+                        let byte_end: usize = byte_start + param.len();
                         params.push(Span {
                             value: param,
-                            span: (param_start..param_end).into(),
+                            span: (byte_start..byte_end).into(),
                         });
                         s.i = param_end;
                     } else {


### PR DESCRIPTION
<!-- Add your description of the PR here -->

Fixes #244

### How has this been tested?

I have first added a failing unit test `parse_query_bind_param_after_utf8_quoted_identifier()` in `src/parser.rs` with the failing query in #244.

### The following has been done
<!-- Mark each item as done by replace the space in '[ ]' with an 'x', e.g. '[x]' -->

- [x] PR title is prefixed with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] The message body above clearly illustrates what problems it solves
- [x] If this PR has changed code within `src`, codegen for the repo has been run with `cargo run --package test_integration -- --apply-codegen`

### Tests and linting

- [x] Formatting has been run with `cargo fmt`
- [x] Tests and lints have been run with `cargo test --all` and `cargo clippy`
