### PR TITLE
feat: add optional TLS support via rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rand 0.10.1",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "sqlx",
  "syn 2.0.117",
@@ -651,7 +654,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "toml 1.1.2+spec-1.1.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -705,6 +710,16 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1029,8 +1044,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1264,6 +1292,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flume"
@@ -2096,6 +2130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2656,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +2762,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2838,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2739,6 +2857,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3379,6 +3520,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3590,31 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami 2.1.1",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid 0.9.6",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3631,6 +3818,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,6 +4019,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,6 +4156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4211,6 +4431,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4511,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,6 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "toml 1.1.2+spec-1.1.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4016,24 +4015,6 @@ checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,25 +60,25 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 tokio-postgres-rustls = { version = "0.13", optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 rustls-pemfile = { version = "2", optional = true }
-webpki-roots = { version = "0.26", optional = true }
 
 [features]
 default = ["tls"]
 # Enables rustls so `clorinde live`/`fresh` can talk to managed Postgres
-# services that require TLS (AWS RDS, Cloud SQL, Neon, Supabase, Aiven, etc.).
+# services that require TLS (Cloud SQL, Neon, Supabase, Aiven, AWS RDS, …).
 # Activated by `sslmode=require|verify-ca|verify-full` in the connection URL.
-# Trust store is the union of:
-#   * the OS native store (Keychain / ca-certificates / Schannel) — picks up
-#     internal corporate CAs the user already trusts, and
-#   * Mozilla's bundle via `webpki-roots` — guarantees common public CAs
-#     (Amazon Root CA 1, ISRG Root X1, …) are present even when the OS store
-#     omits them (e.g. macOS Keychain doesn't ship Amazon roots).
+#
+# Trust store mirrors libpq's behaviour:
+#   * OS native store (Keychain / ca-certificates / Schannel) — covers all
+#     publicly-rooted providers (Let's Encrypt, DigiCert, Amazon Trust
+#     Services, Google Trust Services, …) on a typical machine.
+#   * Optional `PGSSLROOTCERT` PEM bundle — for providers with private
+#     roots (notably AWS RDS / Aurora, which uses an internal `Amazon RDS
+#     Root CA …` hierarchy not present in any public store).
 tls = [
     "dep:rustls",
     "dep:tokio-postgres-rustls",
     "dep:rustls-native-certs",
     "dep:rustls-pemfile",
-    "dep:webpki-roots",
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,33 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "1.1"
 cargo_toml = "0.22"
 
+# TLS (default-on; disable with `--no-default-features` if you only ever
+# point clorinde at a plain-text local Postgres and want a smaller dep tree)
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }
+tokio-postgres-rustls = { version = "0.13", optional = true }
+rustls-native-certs = { version = "0.8", optional = true }
+rustls-pemfile = { version = "2", optional = true }
+webpki-roots = { version = "0.26", optional = true }
+
+[features]
+default = ["tls"]
+# Enables rustls so `clorinde live`/`fresh` can talk to managed Postgres
+# services that require TLS (AWS RDS, Cloud SQL, Neon, Supabase, Aiven, etc.).
+# Activated by `sslmode=require|verify-ca|verify-full` in the connection URL.
+# Trust store is the union of:
+#   * the OS native store (Keychain / ca-certificates / Schannel) — picks up
+#     internal corporate CAs the user already trusts, and
+#   * Mozilla's bundle via `webpki-roots` — guarantees common public CAs
+#     (Amazon Root CA 1, ISRG Root X1, …) are present even when the OS store
+#     omits them (e.g. macOS Keychain doesn't ship Amazon roots).
+tls = [
+    "dep:rustls",
+    "dep:tokio-postgres-rustls",
+    "dep:rustls-native-certs",
+    "dep:rustls-pemfile",
+    "dep:webpki-roots",
+]
+
 [dev-dependencies]
 # Benchmarking
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1,10 +1,18 @@
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
+use tokio_postgres::config::SslMode;
 use tokio_postgres::{Client, Config, NoTls};
 
 use self::error::Error;
 
-/// Creates a non-TLS connection from a URL.
+/// Creates a connection from a URL. Honours the `sslmode` query parameter:
+///
+/// * `disable` / `prefer` → plaintext via `NoTls` (current default behaviour).
+/// * `require` / `verify-ca` / `verify-full` → rustls + the OS native trust
+///   store. Requires the `tls` feature (default-on).
+///
+/// When the `tls` feature is disabled, a TLS-requiring `sslmode` returns
+/// an [`error::Error::Tls`].
 pub(crate) fn from_url(url: &str) -> Result<Client, Error> {
     connect(url.parse()?)
 }
@@ -29,15 +37,94 @@ fn get_runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| Runtime::new().expect("Failed to create Tokio runtime"))
 }
 
+/// Build a rustls `ClientConfig` whose trust store is the union of:
+///
+/// 1. **OS native store** (Keychain on macOS, ca-certificates on Linux,
+///    Schannel on Windows) — picks up corporate CAs the user already trusts.
+/// 2. **Mozilla bundle** (`webpki-roots`) — covers common public CAs
+///    (Amazon Root CA 1, ISRG Root X1, …) some OS stores omit.
+/// 3. **`PGSSLROOTCERT`** — libpq-compatible env var pointing at a PEM
+///    bundle. Used for providers whose roots are private (e.g. AWS RDS
+///    Aurora — point at `aws-rds-global-bundle.pem`).
+///
+/// Validates server certs by signature and chain; hostname verification is
+/// performed by the TLS layer.
+#[cfg(feature = "tls")]
+fn build_rustls_config() -> Result<rustls::ClientConfig, Error> {
+    let mut roots = rustls::RootCertStore::empty();
+
+    // 1) OS native trust store.
+    let native = rustls_native_certs::load_native_certs();
+    for cert in native.certs {
+        let _ = roots.add(cert);
+    }
+
+    // 2) Mozilla bundle (webpki-roots) — fills gaps the native store may miss.
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    // 3) Optional libpq-compatible custom CA bundle.
+    if let Some(path) = std::env::var_os("PGSSLROOTCERT") {
+        let pem = std::fs::read(&path).map_err(|e| {
+            Error::Tls(format!(
+                "failed to read PGSSLROOTCERT={}: {}",
+                std::path::Path::new(&path).display(),
+                e
+            ))
+        })?;
+        let mut cursor = std::io::Cursor::new(pem);
+        let mut added = 0usize;
+        for cert in rustls_pemfile::certs(&mut cursor) {
+            let cert = cert.map_err(|e| Error::Tls(format!("PGSSLROOTCERT parse: {e}")))?;
+            if roots.add(cert).is_ok() {
+                added += 1;
+            }
+        }
+        if added == 0 {
+            return Err(Error::Tls(
+                "PGSSLROOTCERT bundle contained no valid certificates".to_string(),
+            ));
+        }
+    }
+
+    if roots.is_empty() {
+        return Err(Error::Tls(
+            "no trusted root certificates were loaded".to_string(),
+        ));
+    }
+
+    Ok(rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth())
+}
+
 fn connect(config: Config) -> Result<Client, Error> {
     // Use futures::executor::block_on which works from any context
     let (tx, rx) = std::sync::mpsc::channel();
 
     get_runtime().spawn(async move {
-        let result = async {
-            let (client, conn) = config.connect(NoTls).await?;
-            tokio::spawn(conn);
-            Ok::<Client, Error>(client)
+        let result: Result<Client, Error> = async move {
+            let client = match config.get_ssl_mode() {
+                SslMode::Disable | SslMode::Prefer => {
+                    let (c, conn) = config.connect(NoTls).await?;
+                    tokio::spawn(conn);
+                    c
+                }
+                #[cfg(feature = "tls")]
+                _ => {
+                    let tls_cfg = build_rustls_config()?;
+                    let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg);
+                    let (c, conn) = config.connect(tls).await?;
+                    tokio::spawn(conn);
+                    c
+                }
+                #[cfg(not(feature = "tls"))]
+                other => {
+                    return Err(Error::Tls(format!(
+                        "sslmode={other:?} requires building clorinde with the `tls` feature"
+                    )));
+                }
+            };
+            Ok(client)
         }
         .await;
         tx.send(result).unwrap();
@@ -57,6 +144,14 @@ pub(crate) mod error {
     use miette::Diagnostic;
 
     #[derive(Debug, thiserror::Error, Diagnostic)]
-    #[error("Couldn't establish a connection with the database.")]
-    pub struct Error(#[from] pub tokio_postgres::Error);
+    pub enum Error {
+        /// Connection / query failure surfaced by `tokio-postgres`.
+        #[error("Couldn't establish a connection with the database.")]
+        Connection(#[from] tokio_postgres::Error),
+        /// The TLS layer (rustls + native certs) could not be set up, or
+        /// the server requires TLS but clorinde was built without the
+        /// `tls` feature.
+        #[error("TLS error: {0}")]
+        Tls(String),
+    }
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -37,15 +37,18 @@ fn get_runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| Runtime::new().expect("Failed to create Tokio runtime"))
 }
 
-/// Build a rustls `ClientConfig` whose trust store is the union of:
+/// Build a rustls `ClientConfig` whose trust store mirrors libpq's
+/// behaviour:
 ///
 /// 1. **OS native store** (Keychain on macOS, ca-certificates on Linux,
-///    Schannel on Windows) — picks up corporate CAs the user already trusts.
-/// 2. **Mozilla bundle** (`webpki-roots`) — covers common public CAs
-///    (Amazon Root CA 1, ISRG Root X1, …) some OS stores omit.
-/// 3. **`PGSSLROOTCERT`** — libpq-compatible env var pointing at a PEM
-///    bundle. Used for providers whose roots are private (e.g. AWS RDS
-///    Aurora — point at `aws-rds-global-bundle.pem`).
+///    Schannel on Windows) — covers publicly-rooted providers (Let's
+///    Encrypt, DigiCert, Amazon Trust Services, Google Trust Services,
+///    …) and any corporate CAs the user has installed.
+/// 2. **`PGSSLROOTCERT`** — libpq-compatible env var pointing at a PEM
+///    bundle. For providers with private roots (notably AWS RDS / Aurora,
+///    which uses an internal `Amazon RDS Root CA …` hierarchy that is
+///    *not* in any public trust store), point at the provider's bundle
+///    (e.g. `aws-rds-global-bundle.pem`).
 ///
 /// Validates server certs by signature and chain; hostname verification is
 /// performed by the TLS layer.
@@ -59,10 +62,7 @@ fn build_rustls_config() -> Result<rustls::ClientConfig, Error> {
         let _ = roots.add(cert);
     }
 
-    // 2) Mozilla bundle (webpki-roots) — fills gaps the native store may miss.
-    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-    // 3) Optional libpq-compatible custom CA bundle.
+    // 2) Optional libpq-compatible custom CA bundle.
     if let Some(path) = std::env::var_os("PGSSLROOTCERT") {
         let pem = std::fs::read(&path).map_err(|e| {
             Error::Tls(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub fn gen_fresh<P: AsRef<Path>>(
 
     let create_db_query = format!("CREATE DATABASE \"{db_name}\"");
     futures::executor::block_on(server_client.execute(&create_db_query, &[]))
-        .map_err(conn::error::Error)?;
+        .map_err(conn::error::Error::Connection)?;
 
     let db_url = if url.contains('?') {
         format!("{url}&dbname={db_name}")


### PR DESCRIPTION
## Summary

Adds TLS support to `clorinde live` and `clorinde fresh` so the codegen
can connect to managed Postgres services that require encrypted
connections — Cloud SQL, Neon, Supabase, Aiven, AWS RDS / Aurora, etc.
Today both subcommands hard-code `NoTls` and fail with
`no TLS implementation configured` against any server that demands TLS.

> Note: I read `CONTRIBUTING.md` after writing the patch and noticed the
> "open an issue first" guideline for new features. Happy to convert
> this into an issue thread instead — just let me know. The patch is
> small and additive (default-on feature, NoTls path is byte-for-byte
> identical), so I figured a concrete diff might be the most efficient
> starting point for discussion.

## Behaviour

Gated on the standard libpq `sslmode` URL parameter — no surprise TLS:

| `sslmode`                          | Path |
|------------------------------------|------|
| `disable` / `prefer` (default)     | `NoTls` (unchanged) |
| `require` / `verify-ca` / `verify-full` | rustls handshake |

When the new `tls` Cargo feature is **disabled** (`--no-default-features`),
TLS-requiring sslmodes return a clear error instead of a cryptic
`no TLS implementation configured`.

## Trust store — mirrors libpq

1. **OS native store** via `rustls-native-certs` — covers all
   publicly-rooted providers (Let's Encrypt, DigiCert, Amazon Trust
   Services, Google Trust Services, …) and any corporate CAs the user
   has installed (Keychain on macOS, `ca-certificates` on Linux,
   Schannel on Windows).
2. **`PGSSLROOTCERT`** env var — libpq-compatible PEM bundle for
   providers with private roots. AWS RDS / Aurora users point at
   [`aws-rds-global-bundle.pem`](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem)
   since RDS uses an internal `Amazon RDS Root CA …` hierarchy that
   isn't in any public trust store.

`webpki-roots` was considered and dropped: it didn't help the AWS RDS
case (private roots), and it was redundant for the public case (those
roots are already in every modern OS store). Aligning with libpq also
means user OS-level distrust decisions are honoured automatically and
we don't need to ship a clorinde release on every Mozilla update.

## Cargo feature

`tls` is default-on so the common case "just works", but anyone
targeting only plain-text local Postgres can opt out with
`--no-default-features` to keep the dep tree minimal:

```toml
[dependencies]
clorinde = { version = "1.5", default-features = false }
```

New deps when `tls` is enabled:
- `rustls = "0.23"` (`ring` backend)
- `tokio-postgres-rustls = "0.13"`
- `rustls-native-certs = "0.8"`
- `rustls-pemfile = "2"`

## API change (minor)

`conn::error::Error` widens from a tuple struct over
`tokio_postgres::Error` to an enum with `Connection` / `Tls` variants.
The `#[from] tokio_postgres::Error` is preserved so `?` ergonomics are
unchanged for every existing call site. The one tuple-struct
constructor in `gen_fresh` is updated to `Error::Connection`. Outer
`crate::Error::Connection(#[from] conn::error::Error)` continues to
forward.

## Testing

- [x] `cargo build` (default features) — clean
- [x] `cargo build --no-default-features` — clean (NoTls path only)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `clorinde live <url>?sslmode=disable` — regenerates byte-for-byte identical output
- [x] `clorinde live <aws-rds>?sslmode=require` with `PGSSLROOTCERT=aws-rds-global-bundle.pem` — TLS handshake + introspection succeed

CHANGELOG.md left alone since `release-plz.toml` parses `feat:` from
the commit subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)